### PR TITLE
Support setting all actions (not only modify, create and delete).

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
@@ -144,18 +144,7 @@ public class AcHelper {
             } else {
                 history.addVerboseMessage("starting installation of bean: \n"
                         + bean);
-                // check if path exists in CRX
-                if (session.itemExists(bean.getJcrPath())) {
-                    bean.writeToRepository(session, currentPrincipal, history);
-                } else {
-                    String warningMessage = "path: "
-                            + bean.getJcrPath()
-                            + " doesn't exist in repository. Skipped installation of this ACE!";
-                    LOG.warn(warningMessage);
-                    history.addWarning(warningMessage);
-                    continue;
-                }
-
+                bean.install(session, currentPrincipal, history);
             }
         }
     }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
@@ -322,12 +322,12 @@ public class AceBean implements AcDumpElement {
 		cqActions.installActions(getJcrPath(), principal, actionMap,
 				inheritedAllows);
 		
-		Map<String, Value> restrictions = getSingleValueRestrictions(session, acl);
-		if (restrictions.isEmpty()) {
-			return acl;
-		}
 		// since the aclist has been modified, retrieve it again
 		JackrabbitAccessControlList newAcl = AccessControlUtils.getAccessControlList(session, getJcrPath());
+		Map<String, Value> restrictions = getSingleValueRestrictions(session, acl);
+		if (restrictions.isEmpty()) {
+			return newAcl;
+		}
 		// additionally set restrictions on the installed actions (this is not supported by CQ Security API)
 		int newAclSize = newAcl.size();
 		if (previousAclSize >= newAclSize) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
@@ -10,18 +10,24 @@ package biz.netcentric.cq.tools.actool.helper;
 
 import java.security.Principal;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
+import javax.jcr.ValueFormatException;
+import javax.jcr.security.AccessControlEntry;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 
 import biz.netcentric.cq.tools.actool.dumpservice.AcDumpElement;
@@ -49,6 +55,9 @@ public class AceBean implements AcDumpElement {
     private String permission;
     private String[] actions;
     private String assertedExceptionString;
+    
+    
+    public static final String RESTRICTION_NAME_GLOB = "rep:glob";
 
     public String getAssertedExceptionString() {
         return assertedExceptionString;
@@ -242,6 +251,7 @@ public class AceBean implements AcDumpElement {
 			return cleanedPrivileges;
 		}
 		for (String action : actions) {
+			@SuppressWarnings("deprecation")
 			Set<Privilege> coveredPrivileges = cqActions.getPrivileges(action);
 			for (Privilege coveredPrivilege : coveredPrivileges) {
 				cleanedPrivileges.remove(coveredPrivilege.getName());
@@ -249,47 +259,101 @@ public class AceBean implements AcDumpElement {
 		}
 		return cleanedPrivileges;
 	}
+	
 	/**
-	 * Persists the AccessControlEntry being represented by this bean to the
-	 * repository
+	 * Creates a restriction map being used in {@link JackrabbitAccessControlList#addEntry(Principal, Privilege[], boolean, Map)} out of the set actions on this bean.
+	 *
+	 * @param session the session
+	 * @param acl the access control list for which this restriction map should be used
+	 * @return a map with restriction names as keys and restriction values as values.
+	 * @throws ValueFormatException
+	 * @throws UnsupportedRepositoryOperationException
+	 * @throws RepositoryException
 	 */
-	public void writeToRepository(final Session session, Principal principal, AcInstallationHistoryPojo history)
-			throws RepositoryException {
-		AccessControlManager acMgr = session.getAccessControlManager();
-		
-		// Convert actions to permissions, if necessary
-        if (getActions() != null) {
-            // install actions
-            history.addVerboseMessage("adding action for path: "
-                    + getJcrPath() + ", principal: "
-                    + principal.getName() + ", actions: "
-                    + getActionsString() + ", permission: "
-                    + getPermission());
-            AccessControlUtils.addActions(session, this, principal,
-                    history);
-            removeRedundantPrivileges(session);
-        }
-        
-        
-		JackrabbitAccessControlList acl = AccessControlUtils.getModifiableAcl(
-				acMgr, getJcrPath());
-		Set<Privilege> privileges = AccessControlUtils.getPrivilegeSet(
-				getPrivileges(), acMgr);
-		
-		if (!privileges.isEmpty()) {
-			Map<String, Value> restrictions = null;
-			if (getRepGlob() != null) {
-				// is rep:glob supported?
-				for (String rName : acl.getRestrictionNames()) {
-					if ("rep:glob".equals(rName)) {
-						Value v = session.getValueFactory().createValue(
-								getRepGlob(), acl.getRestrictionType(rName));
-						restrictions = Collections.singletonMap(rName, v);
-						break;
-					}
-				}
+	private Map<String, Value> getSingleValueRestrictions(Session session, JackrabbitAccessControlList acl) throws ValueFormatException, UnsupportedRepositoryOperationException, RepositoryException {
+		Collection<String> supportedRestrictionNames = Arrays.asList(acl.getRestrictionNames());
+		if (getRepGlob() != null) {
+			if (!supportedRestrictionNames.contains(RESTRICTION_NAME_GLOB)) {
+				throw new IllegalStateException("The AccessControlList at " + acl.getPath() + " does not support setting rep:glob restrictions!");
 			}
-			if (restrictions != null) {
+			Value v = session.getValueFactory().createValue(getRepGlob(), acl.getRestrictionType(RESTRICTION_NAME_GLOB));
+			return Collections.singletonMap(RESTRICTION_NAME_GLOB, v);
+		} else {
+			return Collections.emptyMap();
+		}
+	}
+ 	
+	/**
+	 * Creates an action map being used in {@link CqActions#installActions(String, Principal, Map, Collection)} out of the set actions on this bean.
+	 * @return a map containing actions as keys and booleans representing {@code true} for allow and {@code false} for deny.
+	 */
+	private Map<String, Boolean> getActionMap() {
+		if (actions == null) {
+			return Collections.emptyMap();
+		}
+		Map<String, Boolean> actionMap = new HashMap<String, Boolean>();
+		for (String action : actions) {
+            actionMap.put(action, isAllow());
+        }
+		return actionMap;
+	}
+
+	/**
+	 * Installs the CQ actions in the repository.
+	 * 
+	 * @param principal
+	 * @param acl
+	 * @param session
+	 * @param acMgr
+	 * @return either the same acl as given in the parameter {@code acl} if no actions have been installed otherwise the new AccessControlList (comprising the entres being installed for the actions).
+	 * @throws RepositoryException
+	 */
+	private JackrabbitAccessControlList installActions(Principal principal, JackrabbitAccessControlList acl, Session session, AccessControlManager acMgr) throws RepositoryException {
+		Map<String, Boolean> actionMap = getActionMap();
+		if (actionMap.isEmpty()) {
+			return acl;
+		}
+		int previousAclSize = acl.size();
+		
+		CqActions cqActions = new CqActions(session);
+		Collection<String> inheritedAllows = cqActions.getAllowedActions(
+				getJcrPath(), Collections.singleton(principal));
+		// this does always install new entries
+		cqActions.installActions(getJcrPath(), principal, actionMap,
+				inheritedAllows);
+		
+		Map<String, Value> restrictions = getSingleValueRestrictions(session, acl);
+		if (restrictions.isEmpty()) {
+			return acl;
+		}
+		// since the aclist has been modified, retrieve it again
+		JackrabbitAccessControlList newAcl = AccessControlUtils.getAccessControlList(session, getJcrPath());
+		// additionally set restrictions on the installed actions (this is not supported by CQ Security API)
+		int newAclSize = newAcl.size();
+		if (previousAclSize >= newAclSize) {
+			throw new IllegalStateException("No new entries have been set for AccessControlList at " + getJcrPath());
+		}
+		AccessControlEntry[] aces = newAcl.getAccessControlEntries();
+		for (int acEntryIndex = previousAclSize; acEntryIndex < newAclSize; acEntryIndex++) {
+			if (!(aces[acEntryIndex] instanceof JackrabbitAccessControlEntry)) {
+				throw new IllegalStateException("Can not deal with non JackrabbitAccessControlEntrys, but entry is of type " + aces[acEntryIndex].getClass().getName());
+			}
+			JackrabbitAccessControlEntry ace = (JackrabbitAccessControlEntry)aces[acEntryIndex];
+			// only extend those AccessControlEntries which do not yet have a restriction
+			if (ace.getRestrictions("rep:glob") == null) {
+				// modify this AccessControlEntry by adding the restriction
+				AccessControlUtils.extendExistingAceWithRestrictions(newAcl, ace, restrictions);
+			}
+		}
+		return newAcl;
+	}
+	
+	private boolean installPrivileges(Principal principal, JackrabbitAccessControlList acl, Session session, AccessControlManager acMgr) throws RepositoryException {
+		// then install remaining privileges
+		Set<Privilege> privileges = AccessControlUtils.getPrivilegeSet(getPrivileges(), acMgr);
+		if (!privileges.isEmpty()) {
+			Map<String, Value> restrictions = getSingleValueRestrictions(session, acl);
+			if (!restrictions.isEmpty()) {
 				acl.addEntry(principal, (Privilege[]) privileges
 						.toArray(new Privilege[privileges.size()]), isAllow(),
 						restrictions);
@@ -297,6 +361,41 @@ public class AceBean implements AcDumpElement {
 				acl.addEntry(principal, (Privilege[]) privileges
 						.toArray(new Privilege[privileges.size()]), isAllow());
 			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Installs the AccessControlEntry being represented by this bean in the
+	 * repository
+	 */
+	public void install(final Session session, Principal principal,
+			AcInstallationHistoryPojo history) throws RepositoryException {
+		AccessControlManager acMgr = session.getAccessControlManager();
+		
+		JackrabbitAccessControlList acl = AccessControlUtils.getModifiableAcl(
+				acMgr, getJcrPath());
+		if (acl == null) {
+			history.addWarning("Skipped installing privileges/actions for non existing path: " + getJcrPath());
+			return;
+		}
+		
+		// first install actions
+		JackrabbitAccessControlList newAcl = installActions(principal, acl, session, acMgr);
+		if (acl != newAcl) {
+			history.addVerboseMessage("added action(s) for path: " + getJcrPath()
+					+ ", principal: " + principal.getName() + ", actions: "
+					+ getActionsString() + ", allow: " + isAllow());
+			removeRedundantPrivileges(session);
+			acl = newAcl;
+		}
+
+		// then install (remaining) privileges
+		if (installPrivileges(principal, acl, session, acMgr)) {
+			history.addVerboseMessage("added privilege(s) for path: " + getJcrPath()
+					+ ", principal: " + principal.getName() + ", privileges: "
+					+ getPrivilegesString() + ", allow: " + isAllow());
 		}
 		acMgr.setPolicy(getJcrPath(), acl);
 	}


### PR DESCRIPTION
In addition support setting restrictions on actions (which is not
supported by the CQ Security API)
Fixes #37