### PR TITLE
do not throw exceptions in case the restriction on an action cannot be

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceBean.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,9 +24,11 @@ import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
 import javax.jcr.ValueFormatException;
 import javax.jcr.security.AccessControlEntry;
+import javax.jcr.security.AccessControlException;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
@@ -313,7 +316,6 @@ public class AceBean implements AcDumpElement {
 		if (actionMap.isEmpty()) {
 			return acl;
 		}
-		int previousAclSize = acl.size();
 		
 		CqActions cqActions = new CqActions(session);
 		Collection<String> inheritedAllows = cqActions.getAllowedActions(
@@ -329,27 +331,56 @@ public class AceBean implements AcDumpElement {
 			return newAcl;
 		}
 		// additionally set restrictions on the installed actions (this is not supported by CQ Security API)
-		int newAclSize = newAcl.size();
-		if (previousAclSize >= newAclSize) {
-			history.addWarning("Could not install restriction for actions " + StringUtils.join(actions, ",") + " at " + getJcrPath() + " because action installation did not lead to a new AC entry. Probably you have defined redundant actions/privileges.");
-		} else {
-			AccessControlEntry[] aces = newAcl.getAccessControlEntries();
-			for (int acEntryIndex = previousAclSize; acEntryIndex < newAclSize; acEntryIndex++) {
-				if (!(aces[acEntryIndex] instanceof JackrabbitAccessControlEntry)) {
-					// this is a non-recoverable error and should never happen
-					throw new IllegalStateException("Can not deal with non JackrabbitAccessControlEntrys, but entry is of type " + aces[acEntryIndex].getClass().getName());
-				}
-				JackrabbitAccessControlEntry ace = (JackrabbitAccessControlEntry)aces[acEntryIndex];
-				// only extend those AccessControlEntries which do not yet have a restriction
-				if (ace.getRestriction("rep:glob") == null) {
-					// modify this AccessControlEntry by adding the restriction
-					AccessControlUtils.extendExistingAceWithRestrictions(newAcl, ace, restrictions);
-				} else {
-					history.addWarning("Could not install restriction for actions " + StringUtils.join(actions, ",") + " at " + getJcrPath() + " because action already has a restriction " + ace.getRestriction("rep:glob").getString());
-				}
+
+		addAdditionalRestriction(acl, newAcl, restrictions);
+		return newAcl;
+	}
+	
+	private void addAdditionalRestriction(JackrabbitAccessControlList oldAcl, JackrabbitAccessControlList newAcl,
+			Map<String, Value> restrictions)
+					throws RepositoryException, AccessControlException, UnsupportedRepositoryOperationException {
+		List<AccessControlEntry> changedAces = getModifiedAces(oldAcl, newAcl);
+		if(!changedAces.isEmpty()){
+			for(AccessControlEntry newAce : changedAces){
+				addRestrictionIfNotSet(newAcl, restrictions, newAce);
+			}
+		}else{
+			// check cornercase: yaml file contains 2 ACEs with same action same principal same path but one with additional restriction (e.g. read and repGlob: '')
+			// in that case old and new acl contain the same elements (equals == true) and in both lists the last ace contains the action without restriction
+			// for that group
+			AccessControlEntry lastOldAce = oldAcl.getAccessControlEntries()[oldAcl.getAccessControlEntries().length-1];
+			AccessControlEntry lastNewAce = newAcl.getAccessControlEntries()[newAcl.getAccessControlEntries().length-1];
+
+			if(lastOldAce.equals(lastNewAce) && lastNewAce.getPrincipal().getName().equals(this.getPrincipalName())){
+				addRestrictionIfNotSet(newAcl, restrictions, lastNewAce);
+
+			}else{
+				throw new IllegalStateException("No new entries have been set for AccessControlList at " + getJcrPath());
 			}
 		}
-		return newAcl;
+	}
+
+	private void addRestrictionIfNotSet(JackrabbitAccessControlList newAcl, Map<String, Value> restrictions,
+			AccessControlEntry newAce)
+					throws RepositoryException, AccessControlException, UnsupportedRepositoryOperationException {
+		if (!(newAce instanceof JackrabbitAccessControlEntry)) {
+			throw new IllegalStateException("Can not deal with non JackrabbitAccessControlEntrys, but entry is of type " + newAce.getClass().getName());
+		}
+		JackrabbitAccessControlEntry ace = (JackrabbitAccessControlEntry)newAce;
+		// only extend those AccessControlEntries which do not yet have a restriction
+
+		if (ace.getRestrictions("rep:glob") == null) {
+			// modify this AccessControlEntry by adding the restriction
+			AccessControlUtils.extendExistingAceWithRestrictions(newAcl, ace, restrictions);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<AccessControlEntry> getModifiedAces(final JackrabbitAccessControlList oldAcl, JackrabbitAccessControlList newAcl) throws RepositoryException{
+		List<AccessControlEntry> oldAces = Arrays.asList(oldAcl.getAccessControlEntries());
+		List<AccessControlEntry> newAces = Arrays.asList(newAcl.getAccessControlEntries());
+		return (List<AccessControlEntry>) CollectionUtils.subtract(newAces, oldAces);
+
 	}
 	
 	private boolean installPrivileges(Principal principal, JackrabbitAccessControlList acl, Session session, AccessControlManager acMgr) throws RepositoryException {


### PR DESCRIPTION
set (might be caused by redundant actions in your configuration)
Fixes #41