### PR TITLE
#54: make CQ5.6.1 the default dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ The package can be installed using the AEM Package Manager or directly from the 
 mvn -PautoInstallPackage install
 ```
 
-## AEM6.x
-To add an Oak Index install, run all commands with profile `oakindex`, e.g.
+## AEM6.x/Oak
+
+The `oakindex-package` contains an optimized Oak index to cover all queries being issued by the Access Control Tool. To build (and optionally deploy) the content-package use the Maven profile oakindex. This package is only compatible with Oak and even there it is optional (as it will only speed up queries).
+
+To use the package, run all commands with profile `oakindex`, e.g.
  ```
 mvn clean install -Poakindex
  ```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ The package can be installed using the AEM Package Manager or directly from the 
 mvn -PautoInstallPackage install
 ```
 
-## Working on CQ5.6
-To deploy to CQ5.6 switch to branch `develop-cq56`.
+## AEM6.x
+To add an Oak Index install, run all commands with profile `oakindex`, e.g.
+ ```
+mvn clean install -Poakindex
+ ```
 
 # Configuration File Format
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ The package can be installed using the AEM Package Manager or directly from the 
 mvn -PautoInstallPackage install
 ```
 
+## Working on CQ5.6
+To deploy to CQ5.6 switch to branch `develop-cq56`.
+
 # Configuration File Format
 
 For better human readability and easy editing the ACL configuration files use the YAML format.

--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -133,7 +133,7 @@
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>oak-core</artifactId>
             <version>1.3.9</version>
-            <scope>compile</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -129,6 +129,12 @@
             <groupId>com.day.jcr.vault</groupId>
             <artifactId>com.day.jcr.vault</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>oak-core</artifactId>
+            <version>1.3.9</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <!-- ====================================================================== -->

--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -24,10 +24,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.adobe.aem</groupId>
-            <artifactId>aem-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
         </dependency>
@@ -120,6 +116,18 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jackrabbit</groupId>
+            <artifactId>jackrabbit-jcr-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.settings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.day.jcr.vault</groupId>
+            <artifactId>com.day.jcr.vault</artifactId>
         </dependency>
     </dependencies>
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/QueryHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/QueryHelper.java
@@ -31,9 +31,11 @@ import javax.jcr.security.AccessControlList;
 import javax.jcr.security.AccessControlManager;
 
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
-import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 
 public class QueryHelper {
+
+	private static final String NT_REP_USER = "rep:User";
+	private static final String NT_REP_GROUP = "rep:Group";
 
 	/**
 	 * Method that returns a set containing all rep:policy nodes from repository
@@ -133,13 +135,13 @@ public class QueryHelper {
 
 	public static Set<String> getUsersFromHome(final Session session)
       throws InvalidQueryException, RepositoryException {
-		Set<String> users = getPrincipalsFromHome(session, UserConstants.NT_REP_USER);
+		Set<String> users = getPrincipalsFromHome(session, NT_REP_USER);
 		return users;
 	}
 
 	public static Set<String> getGroupsFromHome(final Session session)
 			throws InvalidQueryException, RepositoryException {
-		Set<String> groups = getPrincipalsFromHome(session, UserConstants.NT_REP_GROUP);
+		Set<String> groups = getPrincipalsFromHome(session, NT_REP_GROUP);
 		return groups;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Runtime dependencies should be CQ 5.6.1 compatible -->
             <dependency>
                 <groupId>org.apache.jackrabbit</groupId>
                 <artifactId>jackrabbit-jcr-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,13 @@
             </build>
         </profile>
 
+        <profile>
+            <id>oakindex</id>
+            <modules>
+                <module>accesscontroltool-oakindex-package</module>
+            </modules>
+        </profile>
+
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- 5.6.1 dependencies -->
             <dependency>
                 <groupId>org.apache.jackrabbit</groupId>
                 <artifactId>jackrabbit-jcr-commons</artifactId>
@@ -102,7 +101,6 @@
                 <version>5.6.4</version>
                 <scope>provided</scope>
             </dependency>
-            <!-- 5.6.1 dependencies end -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,17 +76,33 @@
     <modules>
         <module>accesscontroltool-bundle</module>
         <module>accesscontroltool-package</module>
-        <module>accesscontroltool-oakindex-package</module>
-    </modules>    
+    </modules>
 
     <dependencyManagement>
         <dependencies>
+            <!-- 5.6.1 dependencies -->
             <dependency>
-                <groupId>com.adobe.aem</groupId>
-                <artifactId>aem-api</artifactId>
-                <version>6.0.0.1</version>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>jackrabbit-jcr-commons</artifactId>
+                <version>2.11.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.settings</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.day.jcr.vault</groupId>
+                <artifactId>com.day.jcr.vault</artifactId>
+                <version>2.4.32</version>
+            </dependency>
+            <dependency>
+                <groupId>com.day.cq</groupId>
+                <artifactId>cq-commons</artifactId>
+                <version>5.6.4</version>
                 <scope>provided</scope>
             </dependency>
+            <!-- 5.6.1 dependencies end -->
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>
@@ -181,12 +197,6 @@
                 <groupId>com.day.cq</groupId>
                 <artifactId>cq-security</artifactId>
                 <version>5.6.2</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.day.cq</groupId>
-                <artifactId>cq-commons</artifactId>
-                <version>5.8.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
             <dependency>
                 <groupId>org.apache.jackrabbit</groupId>
                 <artifactId>jackrabbit-api</artifactId>
-                <version>2.3.0</version>
+                <version>2.7.5</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
I've removed all runtime dependencies to 6.x to ensure the bundle starts under CQ5.6.1

Oak Index package has been moved to a separate profile `oakindex`