### PR TITLE
#71 Allow to set profileContent and preferencesContent 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,7 @@ Every configuration file comprises a group section where groups and their member
 
 ## Configuration of groups
 
-A principal record in configuration file starts with the principal id followed by some indented data records which comprise of:
-
-    optional principalname
-    comma separated list of other groups which the current principal should belong to
-    comma separated list of other groups which are members of the group
-    optional description 
-
-
-Overall format
+A authorizable record in the configuration file starts with the principal id followed by some indented data records containing properties like name/description and group membership:
 
 ```
 [Groupd Id]
@@ -64,7 +56,9 @@ Overall format
      - members: comma separated list of groups that are member of this group
      - description: (optional, description)
      - path: (optional, path of the group in JCR)
-     - migrateFrom: (optional, a group name assigned member users are taken over from, available from v1.7)
+     - migrateFrom: (optional, a group name assigned member users are taken over from, since v1.7)
+
+     
 ```
 
 Example
@@ -85,12 +79,13 @@ The property 'migrateFrom' allows to migrate a group name without loosing their 
 
 In general it is best practice to not generate regular users by the AC Tool but use other mechanism (e.g. LDAP) to create users. However, it can be useful to create system users (e.g. for replication agents or OSGi service authentiation) or test users on staging environments.
 
-Users can be configured in the same way as groups in the **user_config** section. There are two differences to groups:
+Users can be configured in the same way as groups in the **user_config** section. The following properties are different to groups (all optional):
 
 * the attribute "members" cannot be used (for obvious reasons)
-* the attribute "password" can be used for preset passwords 
+* the attribute "password" can be used for preset passwords (not allowed for system users)
 * the boolean attribute isSystemUser is used to create system users in AEM 6.1
-
+* the attribute profileContent allows to provide docview xml that will reset the profile to the given structure after each run, since (since v1.8.2)
+* the attribute preferencesContent allows to provide docview xml that will reset the preferences node to the given structure after each run (since v1.8.2)
 
 ## Configuration of ACEs
 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,7 @@ A authorizable record in the configuration file starts with the principal id fol
      - members: comma separated list of groups that are member of this group
      - description: (optional, description)
      - path: (optional, path of the group in JCR)
-     - migrateFrom: (optional, a group name assigned member users are taken over from, since v1.7)
-
-     
+     - migrateFrom: (optional, a group name assigned member users are taken over from, since v1.7)     
 ```
 
 Example
@@ -84,7 +82,7 @@ Users can be configured in the same way as groups in the **user_config** section
 * the attribute "members" cannot be used (for obvious reasons)
 * the attribute "password" can be used for preset passwords (not allowed for system users)
 * the boolean attribute isSystemUser is used to create system users in AEM 6.1
-* the attribute profileContent allows to provide docview xml that will reset the profile to the given structure after each run, since (since v1.8.2)
+* the attribute profileContent allows to provide docview xml that will reset the profile to the given structure after each run (since v1.8.2)
 * the attribute preferencesContent allows to provide docview xml that will reset the preferences node to the given structure after each run (since v1.8.2)
 
 ## Configuration of ACEs

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableutils/AuthorizableConfigBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableutils/AuthorizableConfigBean.java
@@ -23,29 +23,56 @@ public class AuthorizableConfigBean implements AcDumpElement {
 
     private String principalID;
     private String principalName;
+    private String description;
 
     private String[] memberOf;
-    String memberOfStringFromConfig;
+    private String memberOfStringFromConfig;
 
     private String[] members;
-    String membersStringFromConfig;
+    private String membersStringFromConfig;
 
     private String path;
     private String password;
 
+    private String profileContent;
+    private String preferencesContent;
+    
     private String migrateFrom;
 
     private boolean isGroup = true;
     private boolean isSystemUser = false;
 
-    private String assertedExceptionString = null;
-
-    public String getAssertedExceptionString() {
-        return assertedExceptionString;
+    public String getPrincipalID() {
+        return principalID;
     }
 
-    public void setAssertedExceptionString(final String assertedException) {
-        assertedExceptionString = assertedException;
+    public void setPrincipalID(final String principalID) {
+        this.principalID = principalID;
+    }
+
+    public String getPrincipalName() {
+        return principalName;
+    }
+
+    public void setPrincipalName(final String principalName) {
+        this.principalName = principalName;
+    }
+
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(final String path) {
+        this.path = path;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getPassword() {
@@ -54,6 +81,22 @@ public class AuthorizableConfigBean implements AcDumpElement {
 
     public void setPassword(final String password) {
         this.password = password;
+    }
+    
+    public String getProfileContent() {
+        return profileContent;
+    }
+
+    public void setProfileContent(String profileContent) {
+        this.profileContent = profileContent;
+    }
+
+    public String getPreferencesContent() {
+        return preferencesContent;
+    }
+
+    public void setPreferencesContent(String preferencesContent) {
+        this.preferencesContent = preferencesContent;
     }
 
     public void setMemberOfString(final String memberOfString) {
@@ -78,22 +121,6 @@ public class AuthorizableConfigBean implements AcDumpElement {
 
     public void setIsSystemUser(final boolean isSystemUser) {
         this.isSystemUser = isSystemUser;
-    }
-
-    public String getPrincipalName() {
-        return principalName;
-    }
-
-    public void setAuthorizableName(final String principalName) {
-        this.principalName = principalName;
-    }
-
-    public String getPrincipalID() {
-        return principalID;
-    }
-
-    public void setPrincipalID(final String principalID) {
-        this.principalID = principalID;
     }
 
     public String[] getMemberOf() {
@@ -169,13 +196,6 @@ public class AuthorizableConfigBean implements AcDumpElement {
         this.members = members;
     }
 
-    public String getPath() {
-        return path;
-    }
-
-    public void setPath(final String path) {
-        this.path = path;
-    }
 
     public String getMigrateFrom() {
         return migrateFrom;
@@ -209,5 +229,17 @@ public class AuthorizableConfigBean implements AcDumpElement {
     @Override
     public void accept(final AcDumpElementVisitor acDumpElementVisitor) {
         acDumpElementVisitor.visit(this);
+    }
+
+    // --- only for junit test (TODO: check if test can be refactored to not require
+
+    private String assertedExceptionString = null;
+
+    public String getAssertedExceptionString() {
+        return assertedExceptionString;
+    }
+
+    public void setAssertedExceptionString(final String assertedException) {
+        assertedExceptionString = assertedException;
     }
 }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -57,10 +57,14 @@ public class YamlConfigReader implements ConfigReader {
     private static final String GROUP_CONFIG_PROPERTY_PATH = "path";
     private static final String GROUP_CONFIG_PROPERTY_PASSWORD = "password";
     private static final String GROUP_CONFIG_PROPERTY_NAME = "name";
+    private static final String GROUP_CONFIG_PROPERTY_DESCRIPTION = "description";
+
+    private static final String GROUP_CONFIG_PROPERTY_MIGRATE_FROM = "migrateFrom";
 
     private static final String USER_CONFIG_PROPERTY_IS_SYSTEM_USER = "isSystemUser";
 
-    private static final String GROUP_CONFIG_PROPERTY_MIGRATE_FROM = "migrateFrom";
+    private static final String USER_CONFIG_PROFILE_CONTENT = "profileContent";
+    private static final String USER_CONFIG_PREFERENCES_CONTENT = "preferencesContent";
 
     @Reference
     private SlingRepository repository;
@@ -310,8 +314,11 @@ public class YamlConfigReader implements ConfigReader {
             final String authorizableId,
             boolean isGroupSection) {
         authorizableConfigBean.setPrincipalID(authorizableId);
-        authorizableConfigBean.setAuthorizableName(getMapValueAsString(
+        authorizableConfigBean.setPrincipalName(getMapValueAsString(
                 currentPrincipalDataMap, GROUP_CONFIG_PROPERTY_NAME));
+        authorizableConfigBean.setDescription(getMapValueAsString(
+                currentPrincipalDataMap, GROUP_CONFIG_PROPERTY_DESCRIPTION));
+
         authorizableConfigBean.setMemberOfString(getMapValueAsString(
                 currentPrincipalDataMap, GROUP_CONFIG_PROPERTY_MEMBER_OF));
         // read also memberOf property from legacy scripts
@@ -333,8 +340,16 @@ public class YamlConfigReader implements ConfigReader {
 
         authorizableConfigBean.setPassword(getMapValueAsString(
                 currentPrincipalDataMap, GROUP_CONFIG_PROPERTY_PASSWORD));
+
+
+        authorizableConfigBean.setProfileContent(getMapValueAsString(
+                currentPrincipalDataMap, USER_CONFIG_PROFILE_CONTENT));
+        authorizableConfigBean.setPreferencesContent(getMapValueAsString(
+                currentPrincipalDataMap, USER_CONFIG_PREFERENCES_CONTENT));
+
         authorizableConfigBean.setAssertedExceptionString(getMapValueAsString(
                 currentPrincipalDataMap, ASSERTED_EXCEPTION));
+
     }
 
     private String getMapValueAsString(

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
@@ -100,7 +100,7 @@ public class AcHelper {
             // check if the path even exists
             boolean pathExits = AccessControlUtils.getModifiableAcl(session.getAccessControlManager(), path) != null;
             if (!pathExits) {
-                if (!InitialContentHelper.createInitialContent(session, history, path, aceBeanSetFromConfig)) {
+                if (!ContentHelper.createInitialContent(session, history, path, aceBeanSetFromConfig)) {
                     history.addWarning("Skipped installing privileges/actions for non existing path: " + path);
                     continue;
                 }


### PR DESCRIPTION
Allow to set profileContent, preferencesContent (vlt format) and description (plain string) on authorizable configs. Added documentation.
Fixed unit test BeanValidatorsTest.