### PR TITLE
#143 Possibility to disable saving the history

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/installationhistory/impl/AcHistoryServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/installationhistory/impl/AcHistoryServiceImpl.java
@@ -65,6 +65,14 @@ public class AcHistoryServiceImpl implements AcHistoryService {
 
     @Override
     public void persistHistory(AcInstallationHistoryPojo history) {
+
+    	if (nrOfSavedHistories == 0) {
+        	String message = "History hasn't been persisted, configured number of histories is " + nrOfSavedHistories;
+            history.addVerboseMessage(message);
+            LOG.info(message);
+            return;
+        }
+        
         Session session = null;
         try {
 


### PR DESCRIPTION
To disable history saving the number of histories can be now set to 0 in the next OSGI config
biz.netcentric.cq.tools.actool.installationhistory.impl.AcHistoryServiceImpl.xml