### PR TITLE
remove @modified method to ensure proper calling of @activate of list…

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceservice/impl/AceServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceservice/impl/AceServiceImpl.java
@@ -107,12 +107,6 @@ public class AceServiceImpl implements AceService {
     public void activate(final Map<?, ?> properties)
             throws Exception {
         LOG.debug("Activated AceService!");
-        modified(properties);
-    }
-
-    @Modified
-    public void modified(final Map<?, ?> properties) {
-        LOG.debug("Modified AceService!");
         configurationPath = PropertiesUtil.toString(properties.get(PROPERTY_CONFIGURATION_PATH), "");
         LOG.info("Conifg " + PROPERTY_CONFIGURATION_PATH + "=" + configurationPath);
         intermediateSaves = PropertiesUtil.toBoolean(properties.get(PROPERTY_INTERMEDIATE_SAVES), false);


### PR DESCRIPTION
Remove @modified method to ensure proper calling of @activate of listener service and proper listener re-registration.

Problem without proposed change:

When root path of configuration file is changed with a deployment, the change listener is not re-registered as the registration only happens in the @Activate method of the listener. Removing the @Modifed method in the service, the Service is restarted as well as dependent service such as the listener.