### PR TITLE
Allow spaces in authorizable ids

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
@@ -28,7 +28,7 @@ public class Validators {
     private static final Logger LOG = LoggerFactory.getLogger(Validators.class);
 
     private static final Pattern GROUP_ID_PATTERN = Pattern
-            .compile("([a-zA-Z0-9-_.]+)");
+            .compile("([a-zA-Z0-9-_. ]+)");
 
     public static boolean isValidNodePath(final String path) {
         if (StringUtils.isBlank(path)) {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
@@ -28,9 +28,9 @@ public class ValidatorsTest {
         assertTrue(Validators.isValidAuthorizableId("Group-1"));
         assertTrue(Validators.isValidAuthorizableId("Group-99"));
         assertTrue(Validators.isValidAuthorizableId("Group..9.9"));
+        assertTrue(Validators.isValidAuthorizableId("group A"));
+        assertTrue(Validators.isValidAuthorizableId("group -A"));
 
-        assertFalse(Validators.isValidAuthorizableId("group A"));
-        assertFalse(Validators.isValidAuthorizableId("group -A"));
         assertFalse(Validators.isValidAuthorizableId("group,A"));
         assertFalse(Validators.isValidAuthorizableId("group:A"));
         assertFalse(Validators.isValidAuthorizableId("group;A"));


### PR DESCRIPTION
Please allow spaces in group ids. The GROUP_ID_PATTERN regex is too strict.

I agree that spaces _should_ not be used, but in our setup group ids come from an external system and spaces are common. Also, OAK's UserManager#createGroup(String groupId) can create group ids with spaces just fine.