### PR TITLE
#197 Allow spaces around commas for privileges and restrictions lists in yaml file

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AceBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AceBean.java
@@ -123,7 +123,7 @@ public class AceBean implements AcDumpElement {
                     LOG.debug("Could not get value from restriction map using key: {}", key);
                     continue;
                 }
-                final String[] values = value.split(",");
+                final String[] values = value.split(" *, *");
 
                 restrictions.add(new Restriction(key, values));
             }
@@ -194,7 +194,7 @@ public class AceBean implements AcDumpElement {
 
     public String[] getPrivileges() {
         if (StringUtils.isNotBlank(privilegesString)) {
-            return privilegesString.split(",");
+            return privilegesString.split(" *, *");
         }
         return null;
     }


### PR DESCRIPTION
Allow spaces around commas for privileges and restrictions lists in yaml file