### PR TITLE
Fix: Group-Names with spaces are valid, and often used in Active Directory

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
@@ -28,7 +28,7 @@ public class Validators {
     private static final Logger LOG = LoggerFactory.getLogger(Validators.class);
 
     private static final Pattern GROUP_ID_PATTERN = Pattern
-            .compile("([a-zA-Z0-9-_.]+)");
+            .compile("([a-zA-Z0-9-_. ]+)");
 
     public static boolean isValidNodePath(final String path) {
         if (StringUtils.isBlank(path)) {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
@@ -28,9 +28,9 @@ public class ValidatorsTest {
         assertTrue(Validators.isValidAuthorizableId("Group-1"));
         assertTrue(Validators.isValidAuthorizableId("Group-99"));
         assertTrue(Validators.isValidAuthorizableId("Group..9.9"));
+        assertTrue(Validators.isValidAuthorizableId("group A"));
+        assertTrue(Validators.isValidAuthorizableId("group -A"));
 
-        assertFalse(Validators.isValidAuthorizableId("group A"));
-        assertFalse(Validators.isValidAuthorizableId("group -A"));
         assertFalse(Validators.isValidAuthorizableId("group,A"));
         assertFalse(Validators.isValidAuthorizableId("group:A"));
         assertFalse(Validators.isValidAuthorizableId("group;A"));


### PR DESCRIPTION
Hallo Georg,

wir kennen uns noch von Daimler bzw. der adaptTo-Konferenz. Wir haben das ACTool 1.9.6 bei uns im Projekt benutzt, und wollten jetzt den LDAP (bzw. Active Directory) anbinden.

Leider benutzt mein Kunde ein Namensschema mit Leerzeichen in den Gruppennamen. Für AEM und den LdapIdentityProvider ist das kein Problem. Aber das ACTool prüft den Gruppennamen auf Leerzeichen, und bricht mit einer Exception ab.

Wenn ich angehängten Fix mache, funktioniert es wunderbar. Das einzige Problem war der Validator vom AC Tool. Ich hätte ja gedacht, dass man Leerzeichen nur erlauben sollte, wenn für die Gruppe eine externalId gesetzt ist. Aber anderseits sind ja Leerzeichen erlaubt (ich glaube erst seit AEM 6.1 SP2). Warum dann nicht grundsätzlich erlauben.

Kannst bzw. willst Du den Fix einbauen, und dann auch eine 1.9.7 releasen? Dann müssen wir kein Branch pflegen.

Vielen Dank, und viele Grüße,
Alexander Berndt
