### PR TITLE
#228 remove the <type> definition of the accesscontroltool-bundle …

### DIFF
--- a/accesscontroltool-package/pom.xml
+++ b/accesscontroltool-package/pom.xml
@@ -31,7 +31,6 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>accesscontroltool-bundle</artifactId>
             <version>${project.version}</version>
-            <type>bundle</type>
         </dependency>      
     </dependencies>
     <build>


### PR DESCRIPTION
… to make it possible to easily embed the package without requiring maven-bundle-plugin to be present. 

Fixes #228 