### PR TITLE
fix validation of authorizable id

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/validators/Validators.java
@@ -27,9 +27,6 @@ public class Validators {
 
     private static final Logger LOG = LoggerFactory.getLogger(Validators.class);
 
-    private static final Pattern GROUP_ID_PATTERN = Pattern
-            .compile("([a-zA-Z0-9-_. ]+)");
-
     public static boolean isValidNodePath(final String path) {
         if (StringUtils.isBlank(path)) {
             return true; // repository level permissions are created with 'left-out' path property
@@ -41,17 +38,16 @@ public class Validators {
         return true;
     }
 
-    public static boolean isValidAuthorizableId(final String name) {
-        if (StringUtils.isBlank(name)) {
+    /**
+     * Validates in the same way as <a href="https://github.com/apache/jackrabbit-oak/blob/7999b5cbce87295b502ea4d1622e729f5b96701d/oak-core/src/main/java/org/apache/jackrabbit/oak/security/user/UserManagerImpl.java#L421">Oak's UserManagerImpl</a>.
+     * @param id the authorizable id to validate
+     * @return {@code true} in case the given id is a valid authorizable id, otherwise {@code false}
+     */
+    public static boolean isValidAuthorizableId(final String id) {
+        if (StringUtils.isBlank(id)) {
             return false;
         }
-        boolean isValid = false;
-
-        Matcher matcher = GROUP_ID_PATTERN.matcher(name);
-        if (matcher.matches()) {
-            isValid = true;
-        }
-        return isValid;
+        return true;
     }
 
     public static boolean isValidRegex(String expression) {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/ValidatorsTest.java
@@ -31,13 +31,13 @@ public class ValidatorsTest {
         assertTrue(Validators.isValidAuthorizableId("group A"));
         assertTrue(Validators.isValidAuthorizableId("group -A"));
 
-        assertFalse(Validators.isValidAuthorizableId("group,A"));
-        assertFalse(Validators.isValidAuthorizableId("group:A"));
-        assertFalse(Validators.isValidAuthorizableId("group;A"));
-        // FIXME: There were non-ASCII characters here. Use Unicode escape
-        // sequences instead.
-        assertFalse(Validators.isValidAuthorizableId("group-??"));
-        assertFalse(Validators.isValidAuthorizableId("group*A"));
+        assertTrue(Validators.isValidAuthorizableId("group,A"));
+        assertTrue(Validators.isValidAuthorizableId("group:A"));
+        assertTrue(Validators.isValidAuthorizableId("group;A"));
+      
+        // even unicode characters are fine
+        assertTrue(Validators.isValidAuthorizableId("group-\\u00F8\\u00FCa"));
+        // only empty string not allowed
         assertFalse(Validators.isValidAuthorizableId(""));
         assertFalse(Validators.isValidAuthorizableId(null));
     }

--- a/accesscontroltool-bundle/src/test/resources/testconfig.yaml
+++ b/accesscontroltool-bundle/src/test/resources/testconfig.yaml
@@ -15,14 +15,6 @@
          path: /home/groups/g
          
          
-    # invalid group name 
-    - groupÄ:
-
-       - name: 
-         isMemberOf: 
-         path: /home/groups/g
-         assertedException: InvalidGroupNameException
-         
     - group_B:
 
        - isMemberOf:
@@ -83,13 +75,7 @@
          path: /home/groups/
          assertedException: InvalidIntermediatePathException
          
-    # invalid isMemberOf-name name
-    - group_O:
-
-       - isMemberOf: group_Ö
-         path: /home/groups/g
-         assertedException: InvalidGroupNameException
-         
+    
 - user_config:  
        
     - user_A:


### PR DESCRIPTION
only validate that it is not empty as Oak imposes no other restrictions. 
Fixes #234