### PR TITLE
#251: use CryptoSupport for passwords enclosed in brackets.

### DIFF
--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -104,6 +104,10 @@
             <artifactId>cq-commons</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.crypto</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.13</version>

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/AuthorizableInstallerService.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/AuthorizableInstallerService.java
@@ -11,13 +11,16 @@ package biz.netcentric.cq.tools.actool.authorizableinstaller;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import com.adobe.granite.crypto.CryptoException;
+
 import biz.netcentric.cq.tools.actool.configmodel.AuthorizablesConfig;
 import biz.netcentric.cq.tools.actool.history.AcInstallationLog;
 
 public interface AuthorizableInstallerService {
 
-    public void installAuthorizables(
+    void installAuthorizables(
             AuthorizablesConfig principalMapFromConfig,
-            final Session session, AcInstallationLog installLog) throws RepositoryException, AuthorizableCreatorException;
+            final Session session, AcInstallationLog installLog)
+            throws RepositoryException, AuthorizableCreatorException, CryptoException;
 
 }

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImplTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImplTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -40,248 +41,310 @@ import org.hamcrest.Description;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.junit.runners.Enclosed;
+import org.junit.runners.Parameterized;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
+
+import com.adobe.granite.crypto.CryptoException;
+import com.adobe.granite.crypto.CryptoSupport;
 
 import biz.netcentric.cq.tools.actool.configmodel.AcConfiguration;
 import biz.netcentric.cq.tools.actool.configmodel.AuthorizableConfigBean;
 import biz.netcentric.cq.tools.actool.configmodel.GlobalConfiguration;
 import biz.netcentric.cq.tools.actool.history.AcInstallationLog;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(Enclosed.class)
 public class AuthorizableInstallerServiceImplTest {
 
-    public static final String TESTGROUP = "testGroup";
+    @RunWith(MockitoJUnitRunner.class)
+    public static final class BASE_TESTS {
+        public static final String TESTGROUP = "testGroup";
 
-    public static final String GROUP1 = "group1";
-    public static final String GROUP2 = "group2";
-    public static final String GROUP3 = "group3";
-    public static final String EXTERNALGROUP = "externalGroup";
+        public static final String GROUP1 = "group1";
+        public static final String GROUP2 = "group2";
+        public static final String GROUP3 = "group3";
+        public static final String EXTERNALGROUP = "externalGroup";
 
-    public static final String USER1 = "user1";
+        public static final String USER1 = "user1";
 
-    public static final String SYSTEM_USER1 = "systemuser1";
+        public static final String SYSTEM_USER1 = "systemuser1";
 
-    // class under test
-    @Spy
-    private AuthorizableInstallerServiceImpl cut = new AuthorizableInstallerServiceImpl();
-    
-    private AcConfiguration acConfiguration = new AcConfiguration();
-    private GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-    private AcInstallationLog status = new AcInstallationLog();
+        // class under test
+        @Spy
+        private AuthorizableInstallerServiceImpl cut = new AuthorizableInstallerServiceImpl();
 
-    @Mock
-    private UserManager userManager;
+        private AcConfiguration acConfiguration = new AcConfiguration();
+        private GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        private AcInstallationLog status = new AcInstallationLog();
 
-    @Mock
-    private Session session;
-    @Mock
-    private ValueFactory valueFactory;
+        @Mock
+        private UserManager userManager;
 
-    @Mock
-    private Group testGroup;
+        @Mock
+        private Session session;
+        @Mock
+        private ValueFactory valueFactory;
 
-    @Mock
-    private Group group1;
+        @Mock
+        private Group testGroup;
 
-    @Mock
-    private Group group2;
+        @Mock
+        private Group group1;
 
-    @Mock
-    private Group group3;
+        @Mock
+        private Group group2;
 
-    @Mock
-    private Group externalGroup;
-    
-    @Mock
-    private User systemUser1;
+        @Mock
+        private Group group3;
 
-    @Mock
-    private User regularUser1;
+        @Mock
+        private Group externalGroup;
 
-    @Before
-    public void setup() throws RepositoryException {
+        @Mock
+        private User systemUser1;
 
-        doReturn(valueFactory).when(session).getValueFactory();
-        Mockito.when(valueFactory.createValue(anyString())).thenAnswer(new Answer<Value>() {
-            @Override
-            public Value answer(InvocationOnMock invocation) throws Throwable {
-                Value mock = mock(Value.class);
-                Object val = invocation.getArguments()[0];
-                doReturn(val).when(mock).getString();
-                return mock;
-            }
-        });
+        @Mock
+        private User regularUser1;
 
-        status.setAcConfiguration(acConfiguration);
-        acConfiguration.setGlobalConfiguration(globalConfiguration);
+        @Before
+        public void setup() throws RepositoryException {
 
-        setupAuthorizable(testGroup, TESTGROUP, true, false);
-        setupAuthorizable(group1, GROUP1, true, false);
-        setupAuthorizable(group2, GROUP2, true, false);
-        setupAuthorizable(group3, GROUP3, true, false);
-        setupAuthorizable(externalGroup, EXTERNALGROUP, true, false);
-
-        setupAuthorizable(systemUser1, SYSTEM_USER1, false, true);
-        setupAuthorizable(regularUser1, USER1, false, false);
-    }
-
-    private void setupAuthorizable(Authorizable authorizable, String id, boolean isGroup, boolean isSystemUser) throws RepositoryException {
-        doReturn(authorizable).when(userManager).getAuthorizable(id);
-        doReturn(id).when(authorizable).getID();
-        doReturn(isGroup).when(authorizable).isGroup();
-        doReturn("/home/" + (isGroup ? "groups" : "users") + (isSystemUser ? "/system" : "") + "/test").when(authorizable).getPath();
-    }
-    
-    @Test
-    public void testApplyGroupMembershipConfigIsMemberOf() throws Exception {
-        HashSet<String> configuredGroups = new HashSet<String>(Arrays.asList(GROUP1, GROUP2));
-        HashSet<String> groupsInRepo = new HashSet<String>(Arrays.asList(GROUP2, GROUP3, EXTERNALGROUP));
-
-        globalConfiguration.setDefaultUnmanagedExternalIsMemberOfRegex("external.*");
-
-        // just return the value as passed in as fourth argument
-        doAnswer(new Answer<Set<String>>() {
-            public Set<String> answer(InvocationOnMock invocation) throws Throwable {
-                return (Set<String>) invocation.getArguments()[3];
-            }
-        }).when(cut).validateAssignedGroups(userManager, null, TESTGROUP, configuredGroups, status);
-
-        Set<String> authorizablesInConfig = new HashSet<String>(asList(GROUP1));
-        cut.applyGroupMembershipConfigIsMemberOf(TESTGROUP, status, userManager, null, configuredGroups, groupsInRepo,
-                authorizablesInConfig);
-        
-        verifyZeroInteractions(group2); // in configuredGroups and in groupsInRepo
-        verifyZeroInteractions(externalGroup); // matches external.* and hence must not be removed (even though it is not in the
-                                               // configuration)
-        
-        verify(group1).addMember(testGroup);
-        verifyNoMoreInteractions(group1);
-
-        verify(group3).removeMember(testGroup);
-        verifyNoMoreInteractions(group3);
-        
-    }
-    
-    @Test
-    public void testApplyGroupMembershipConfigMembers() throws Exception {
-
-        AcInstallationLog history = new AcInstallationLog();
-        history.setAcConfiguration(new AcConfiguration());
-        history.getAcConfiguration().setGlobalConfiguration(new GlobalConfiguration());
-
-        AuthorizableConfigBean authorizableConfigBean = new AuthorizableConfigBean();
-        authorizableConfigBean.setAuthorizableId(TESTGROUP);
-
-        Set<String> authorizablesInConfig = new HashSet<String>(asList(GROUP1));
-
-        // test no change
-        authorizableConfigBean.setMembers(new String[] { GROUP2, GROUP3, SYSTEM_USER1 });
-        doReturn(asList(group2, group3, regularUser1, systemUser1).iterator()).when(testGroup).getDeclaredMembers();
-        cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
-        verify(testGroup, times(0)).addMember(any(Authorizable.class));
-        verify(testGroup, times(0)).removeMember(any(Authorizable.class));
-        reset(testGroup);
-
-        // test removed in config
-        authorizableConfigBean.setMembers(new String[] {});
-        doReturn(asList(group2, group3, regularUser1, systemUser1).iterator()).when(testGroup).getDeclaredMembers();
-        cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
-        verify(testGroup, times(0)).addMember(any(Authorizable.class));
-        verify(testGroup).removeMember(group2);
-        verify(testGroup).removeMember(group3);
-        verify(testGroup).removeMember(systemUser1);
-        verify(testGroup, times(0)).removeMember(regularUser1);// regular user must not be removed
-        reset(testGroup);
-
-        // test to be added as in config but not in repo
-        authorizableConfigBean.setMembers(new String[] { GROUP2, GROUP3, SYSTEM_USER1 });
-        doReturn(asList().iterator()).when(testGroup).getDeclaredMembers();
-        cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
-        verify(testGroup).addMember(group2);
-        verify(testGroup).addMember(group3);
-        verify(testGroup).addMember(systemUser1);
-        verify(testGroup, times(0)).removeMember(any(Authorizable.class));
-        reset(testGroup);
-
-        // test authorizable in config not removed
-        authorizableConfigBean.setMembers(new String[] {});
-        doReturn(asList(group1, group2).iterator()).when(testGroup).getDeclaredMembers();
-        cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
-        verify(testGroup, times(0)).addMember(any(Authorizable.class));
-        verify(testGroup, times(0)).removeMember(group1); // must not be removed since it's contained in config
-        verify(testGroup).removeMember(group2);
-        reset(testGroup);
-
-        // test authorizable in config not removed if defaultUnmanagedExternalMembersRegex is configured
-        history.getAcConfiguration().getGlobalConfiguration().setDefaultUnmanagedExternalMembersRegex("group2.*");
-        authorizableConfigBean.setMembers(new String[] {});
-        doReturn(asList(group1, group2).iterator()).when(testGroup).getDeclaredMembers();
-        cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
-        verify(testGroup, times(0)).addMember(any(Authorizable.class));
-        verify(testGroup, times(0)).removeMember(group1); // must not be removed since it's contained in config
-        verify(testGroup, times(0)).removeMember(group2); // must not be removed since allowExternalGroupNamesRegEx config
-        reset(testGroup);
-
-    }
-    
-    
-    @Test
-    public void testSetAuthorizableProperties() throws Exception {
-        
-        AuthorizableConfigBean authorizableConfig = new AuthorizableConfigBean();
-        authorizableConfig.setIsGroup(false);
-
-        authorizableConfig.setName("John Doe");
-        authorizableConfig.setDescription("Test Description");
-
-        cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
-
-        verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("John")));
-        verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Doe")));
-        verify(regularUser1).setProperty(eq("profile/aboutMe"), Matchers.argThat(new ValueMatcher("Test Description")));
-
-        authorizableConfig.setName("Van der Broek, Sebastian");
-        cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
-        verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("Sebastian")));
-        verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Van der Broek")));
-
-        authorizableConfig.setName("Johann Sebastian Bach");
-        cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
-        verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("Johann Sebastian")));
-        verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Bach")));
-
-    }
-
-    private final class ValueMatcher extends BaseMatcher<Value> {
-        private String expectedVal;
-
-        public ValueMatcher(String expectedVal) {
-            this.expectedVal = expectedVal;
-        }
-
-        @Override
-        public boolean matches(Object actualVal) {
-            if (!(actualVal instanceof Value)) {
-                return false;
-            } else {
-                try {
-                    return StringUtils.equals(((Value) actualVal).getString(), expectedVal);
-                } catch (IllegalStateException | RepositoryException e) {
-                    return false;
+            doReturn(valueFactory).when(session).getValueFactory();
+            Mockito.when(valueFactory.createValue(anyString())).thenAnswer(new Answer<Value>() {
+                @Override
+                public Value answer(InvocationOnMock invocation) throws Throwable {
+                    Value mock = mock(Value.class);
+                    Object val = invocation.getArguments()[0];
+                    doReturn(val).when(mock).getString();
+                    return mock;
                 }
-            }
+            });
+
+            status.setAcConfiguration(acConfiguration);
+            acConfiguration.setGlobalConfiguration(globalConfiguration);
+
+            setupAuthorizable(testGroup, TESTGROUP, true, false);
+            setupAuthorizable(group1, GROUP1, true, false);
+            setupAuthorizable(group2, GROUP2, true, false);
+            setupAuthorizable(group3, GROUP3, true, false);
+            setupAuthorizable(externalGroup, EXTERNALGROUP, true, false);
+
+            setupAuthorizable(systemUser1, SYSTEM_USER1, false, true);
+            setupAuthorizable(regularUser1, USER1, false, false);
+        }
+
+        private void setupAuthorizable(Authorizable authorizable, String id, boolean isGroup, boolean isSystemUser) throws RepositoryException {
+            doReturn(authorizable).when(userManager).getAuthorizable(id);
+            doReturn(id).when(authorizable).getID();
+            doReturn(isGroup).when(authorizable).isGroup();
+            doReturn("/home/" + (isGroup ? "groups" : "users") + (isSystemUser ? "/system" : "") + "/test").when(authorizable).getPath();
+        }
+
+        @Test
+        public void testApplyGroupMembershipConfigIsMemberOf() throws Exception {
+            HashSet<String> configuredGroups = new HashSet<String>(Arrays.asList(GROUP1, GROUP2));
+            HashSet<String> groupsInRepo = new HashSet<String>(Arrays.asList(GROUP2, GROUP3, EXTERNALGROUP));
+
+            globalConfiguration.setDefaultUnmanagedExternalIsMemberOfRegex("external.*");
+
+            // just return the value as passed in as fourth argument
+            doAnswer(new Answer<Set<String>>() {
+                public Set<String> answer(InvocationOnMock invocation) throws Throwable {
+                    return (Set<String>) invocation.getArguments()[3];
+                }
+            }).when(cut).validateAssignedGroups(userManager, null, TESTGROUP, configuredGroups, status);
+
+            Set<String> authorizablesInConfig = new HashSet<String>(asList(GROUP1));
+            cut.applyGroupMembershipConfigIsMemberOf(TESTGROUP, status, userManager, null, configuredGroups, groupsInRepo,
+                    authorizablesInConfig);
+
+            verifyZeroInteractions(group2); // in configuredGroups and in groupsInRepo
+            verifyZeroInteractions(externalGroup); // matches external.* and hence must not be removed (even though it is not in the
+            // configuration)
+
+            verify(group1).addMember(testGroup);
+            verifyNoMoreInteractions(group1);
+
+            verify(group3).removeMember(testGroup);
+            verifyNoMoreInteractions(group3);
 
         }
 
-        @Override
-        public void describeTo(Description desc) {
-            desc.appendText(" is " + expectedVal);
+        @Test
+        public void testApplyGroupMembershipConfigMembers() throws Exception {
+
+            AcInstallationLog history = new AcInstallationLog();
+            history.setAcConfiguration(new AcConfiguration());
+            history.getAcConfiguration().setGlobalConfiguration(new GlobalConfiguration());
+
+            AuthorizableConfigBean authorizableConfigBean = new AuthorizableConfigBean();
+            authorizableConfigBean.setAuthorizableId(TESTGROUP);
+
+            Set<String> authorizablesInConfig = new HashSet<String>(asList(GROUP1));
+
+            // test no change
+            authorizableConfigBean.setMembers(new String[] { GROUP2, GROUP3, SYSTEM_USER1 });
+            doReturn(asList(group2, group3, regularUser1, systemUser1).iterator()).when(testGroup).getDeclaredMembers();
+            cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
+            verify(testGroup, times(0)).addMember(any(Authorizable.class));
+            verify(testGroup, times(0)).removeMember(any(Authorizable.class));
+            reset(testGroup);
+
+            // test removed in config
+            authorizableConfigBean.setMembers(new String[] {});
+            doReturn(asList(group2, group3, regularUser1, systemUser1).iterator()).when(testGroup).getDeclaredMembers();
+            cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
+            verify(testGroup, times(0)).addMember(any(Authorizable.class));
+            verify(testGroup).removeMember(group2);
+            verify(testGroup).removeMember(group3);
+            verify(testGroup).removeMember(systemUser1);
+            verify(testGroup, times(0)).removeMember(regularUser1);// regular user must not be removed
+            reset(testGroup);
+
+            // test to be added as in config but not in repo
+            authorizableConfigBean.setMembers(new String[] { GROUP2, GROUP3, SYSTEM_USER1 });
+            doReturn(asList().iterator()).when(testGroup).getDeclaredMembers();
+            cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
+            verify(testGroup).addMember(group2);
+            verify(testGroup).addMember(group3);
+            verify(testGroup).addMember(systemUser1);
+            verify(testGroup, times(0)).removeMember(any(Authorizable.class));
+            reset(testGroup);
+
+            // test authorizable in config not removed
+            authorizableConfigBean.setMembers(new String[] {});
+            doReturn(asList(group1, group2).iterator()).when(testGroup).getDeclaredMembers();
+            cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
+            verify(testGroup, times(0)).addMember(any(Authorizable.class));
+            verify(testGroup, times(0)).removeMember(group1); // must not be removed since it's contained in config
+            verify(testGroup).removeMember(group2);
+            reset(testGroup);
+
+            // test authorizable in config not removed if defaultUnmanagedExternalMembersRegex is configured
+            history.getAcConfiguration().getGlobalConfiguration().setDefaultUnmanagedExternalMembersRegex("group2.*");
+            authorizableConfigBean.setMembers(new String[] {});
+            doReturn(asList(group1, group2).iterator()).when(testGroup).getDeclaredMembers();
+            cut.applyGroupMembershipConfigMembers(authorizableConfigBean, history, TESTGROUP, userManager, authorizablesInConfig);
+            verify(testGroup, times(0)).addMember(any(Authorizable.class));
+            verify(testGroup, times(0)).removeMember(group1); // must not be removed since it's contained in config
+            verify(testGroup, times(0)).removeMember(group2); // must not be removed since allowExternalGroupNamesRegEx config
+            reset(testGroup);
+
+        }
+
+
+        @Test
+        public void testSetAuthorizableProperties() throws Exception {
+
+            AuthorizableConfigBean authorizableConfig = new AuthorizableConfigBean();
+            authorizableConfig.setIsGroup(false);
+
+            authorizableConfig.setName("John Doe");
+            authorizableConfig.setDescription("Test Description");
+
+            cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
+
+            verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("John")));
+            verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Doe")));
+            verify(regularUser1).setProperty(eq("profile/aboutMe"), Matchers.argThat(new ValueMatcher("Test Description")));
+
+            authorizableConfig.setName("Van der Broek, Sebastian");
+            cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
+            verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("Sebastian")));
+            verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Van der Broek")));
+
+            authorizableConfig.setName("Johann Sebastian Bach");
+            cut.setAuthorizableProperties(regularUser1, authorizableConfig, session, status);
+            verify(regularUser1).setProperty(eq("profile/givenName"), Matchers.argThat(new ValueMatcher("Johann Sebastian")));
+            verify(regularUser1).setProperty(eq("profile/familyName"), Matchers.argThat(new ValueMatcher("Bach")));
+
+        }
+
+        private final class ValueMatcher extends BaseMatcher<Value> {
+            private String expectedVal;
+
+            public ValueMatcher(String expectedVal) {
+                this.expectedVal = expectedVal;
+            }
+
+            @Override
+            public boolean matches(Object actualVal) {
+                if (!(actualVal instanceof Value)) {
+                    return false;
+                } else {
+                    try {
+                        return StringUtils.equals(((Value) actualVal).getString(), expectedVal);
+                    } catch (IllegalStateException | RepositoryException e) {
+                        return false;
+                    }
+                }
+
+            }
+
+            @Override
+            public void describeTo(Description desc) {
+                desc.appendText(" is " + expectedVal);
+            }
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static final class SetUserPassword {
+
+        private static final String UNPROTECTED_PASSWORD = "unprotected_pass";
+
+        @Mock
+        private User user;
+
+        @Mock
+        private CryptoSupport cryptoSupportMock;
+
+        private AuthorizableInstallerServiceImpl service;
+
+        private String password;
+        private String expectedPassword;
+
+        public SetUserPassword(String password, String expectedPassword) {
+            this.password = password;
+            this.expectedPassword = expectedPassword;
+        }
+
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                    { "{some_protected_pass}", UNPROTECTED_PASSWORD },
+                    { "bracketsAtTheEnd{pass}", "bracketsAtTheEnd{pass}" },
+                    { "{pass}bracketsAtTheStart", "{pass}bracketsAtTheStart" },
+                    { "bracketsIn{pass}TheMiddle", "bracketsIn{pass}TheMiddle" },
+                    { "noBrackets", "noBrackets" },
+            });
+        }
+
+        @Before
+        public void setUp() throws CryptoException {
+            MockitoAnnotations.initMocks(this);
+
+            service = new AuthorizableInstallerServiceImpl();
+            service.cryptoSupport = cryptoSupportMock;
+
+            doReturn(UNPROTECTED_PASSWORD).when(cryptoSupportMock).unprotect(anyString());
+        }
+
+        @Test
+        public void test() throws RepositoryException, CryptoException {
+            final AuthorizableConfigBean bean = new AuthorizableConfigBean();
+            bean.setPassword(password);
+
+            service.setUserPassword(bean, user);
+
+            verify(user).changePassword(eq(expectedPassword));
         }
     }
 }

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -77,7 +77,7 @@ property | comment | required
 --- | --- | ---
 name | Works mostly like for groups, except that the string is split up in first and last name using the last space found in string. For instance "Johann Sebastian Bach" will result in first name "Johann Sebastian" and last name "Bach". For names where the split has to be explicitly configured, use a comma: "Van der Broek, Sebastian" will result in first name "Sebastian" and last name "Van der Broek" | optional
 description, path, isMemberOf | Work exactly as for groups | optional
-password | The PW for the user. Obviously this is stored in plain text and should only be used for test users | Required for non-system users, otherwise must not be set
+password | The PW for the user. Can be stored in plain text (only to be used for test users). If a password value is enclosed in brackets, then it will be automatically decrypted using com.adobe.granite.crypto.CryptoSupport. `/system/console/crypto` on target instance can be used to get encrypted password. Encrypted password (together with braces) should also be enclosed in double quotes. | Required for non-system users, otherwise must not be set
 isSystemUser | Create users as system user (AEM 6.1 and later) | optional
 disabled | Can be set to `true` or an arbitrary reason string to disable a user. If set to `false` the user will be explicitly enabled (calling `User.disable(null)`). If omitted will not change anything regarding enabled/disabled status of user | optional
 profileContent | Allows to provide [enhanced docview xml](https://jackrabbit.apache.org/filevault/apidocs/org/apache/jackrabbit/vault/util/DocViewProperty.html) that will reset the profile to the given structure after each run (since v1.8.2, enhanced docview since v1.9.1) | optional
@@ -91,6 +91,10 @@ Example:
   - editor:
     - isMemberOf: myeditors
       password: secret
+      
+  - replicationReceiver:
+    - name: "Replication receiver"
+      password: "{someEncryptedValue}"
       
   - poweruser:
     - name: "Power User"

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>com.adobe.granite</groupId>
                 <artifactId>com.adobe.granite.crypto</artifactId>
-                <version>3.0.18-CQ610-B0004</version>
+                <version>3.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>com.adobe.granite</groupId>
+                <artifactId>com.adobe.granite.crypto</artifactId>
+                <version>3.0.18-CQ610-B0004</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.core</artifactId>
                 <version>4.2.0</version>


### PR DESCRIPTION
Tested on AEM 6.1 SP1 and AEM 6.3 via JMX apply method.