### PR TITLE
Prevent NPE while logging errors

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
@@ -100,7 +100,7 @@ public abstract class BaseAceBeanInstaller implements AceBeanInstaller {
 
         if (history.getMissingParentPathsForInitialContent() > 0) {
             history.addWarning(LOG, "There were " + history.getMissingParentPathsForInitialContent()
-                    + " parent paths missing for creation of intial content (those paths were skipped, see verbose log for details)");
+                    + " parent paths missing for creation of initial content (those paths were skipped, see verbose log for details)");
         }
 
         history.addMessage(LOG, "ACL Update Statistics: Changed=" + history.getCountAclsChanged() + " Unchanged=" + history.getCountAclsUnchanged()

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/InstallationLogger.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/InstallationLogger.java
@@ -11,10 +11,6 @@ public interface InstallationLogger extends InstallationLog {
 
     void addVerboseMessage(Logger log, String message);
 
-    void addError(final String error);
-
-    void addError(Logger log, String error);
-
     void addError(String error, Throwable e);
 
     void addError(Logger log, String error, Throwable e);

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/PersistableInstallationLogger.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/PersistableInstallationLogger.java
@@ -138,20 +138,10 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
         addError(error, e);
     }
 
-    @Override
-    public void addError(Logger log, String error) {
-        log.error(error);
-        addError(error);
-    }
-
     public void addError(final String error, Throwable e) {
-        addError(error + " / e=" + e);
-    }
-
-    @Override
-    public void addError(final String error) {
+        String fullErrorValue = error + " / e=" + e;
         errors.add(new HistoryEntry(msgIndex, new Timestamp(
-                new Date().getTime()), MSG_IDENTIFIER_ERROR + error));
+                new Date().getTime()), MSG_IDENTIFIER_ERROR + fullErrorValue));
         success = false;
         msgIndex++;
     }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/ProgressTrackerListenerInstallationLogger.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/ProgressTrackerListenerInstallationLogger.java
@@ -25,12 +25,6 @@ public class ProgressTrackerListenerInstallationLogger extends PersistableInstal
     }
 
     @Override
-    public void addError(String error) {
-        listener.onError(ProgressTrackerListener.Mode.TEXT, MSG_IDENTIFIER_ERROR + error, null);
-        super.addError(error);
-    }
-
-    @Override
     public void addError(String error, Throwable t) {
         Exception e;
         if (t instanceof Exception) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
@@ -214,8 +214,7 @@ public class AcInstallationServiceImpl implements AcInstallationService, AcInsta
             LOG.info("Successfully applied AC Tool configuration in " + msHumanReadable(executionTime));
             installLog.setExecutionTime(executionTime);
         } catch (Exception e) {
-            // TODO: separate exception
-            installLog.addError(e.toString()); // ensure exception is added to installLog before it's persisted in log in finally clause
+            installLog.addError("Could not process yaml files", e); // ensure exception is added to installLog before it's persisted in log in finally clause
             throw e; // handling is different depending on JMX or install hook case
         } finally {
             try {


### PR DESCRIPTION
The ProgressTrackerListener doesn't support a null exception in its
onError message. Therefore remove all error messages not receiving a
throwable (or a null throwable).

This closes #260