### PR TITLE
Adding missing unmanaged* config properties

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
@@ -89,7 +89,8 @@ public abstract class BaseAceBeanInstaller implements AceBeanInstaller {
             orderedAceBeanSetFromConfig.addAll(aceBeanSetFromConfig);
 
             Set<String> principalsToRemoveAcesForAtThisPath = acConfiguration.getAuthorizablesConfig()
-                    .removeUnmanagedPrincipalNamesAtPath(path, principalsToRemoveAcesFor);
+                    .removeUnmanagedPrincipalNamesAtPath(path, principalsToRemoveAcesFor,
+                            acConfiguration.getGlobalConfiguration().getDefaultUnmanagedAcePathsRegex());
             installAcl(orderedAceBeanSetFromConfig, path, principalsToRemoveAcesForAtThisPath, session, history);
 
             if (intermediateSaves && session.hasPendingChanges()) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
@@ -224,8 +224,11 @@ public class AuthorizableInstallerServiceImpl implements
     private Set<String> removeExternalMembersUnmanagedByConfiguration(AcConfiguration acConfiguration, AuthorizableConfigBean authorizableConfigBean,
             Set<String> relevantMembersInRepo, InstallationLogger installLog) {
         Set<String> relevantMembers = new HashSet<String>(relevantMembersInRepo);
-        Pattern unmanagedExternalMembersRegex = acConfiguration.getGlobalConfiguration()
-                .getDefaultUnmanagedExternalMembersRegex();
+
+        Pattern unmanagedExternalMembersRegex = authorizableConfigBean.getUnmanagedExternalMembersRegex();
+        if (unmanagedExternalMembersRegex == null) {
+            unmanagedExternalMembersRegex = acConfiguration.getGlobalConfiguration().getDefaultUnmanagedExternalMembersRegex();
+        }
 
         Set<String> unmanagedMembers = new HashSet<String>();
         if (unmanagedExternalMembersRegex != null) {
@@ -413,13 +416,13 @@ public class AuthorizableInstallerServiceImpl implements
             AuthorizableConfigBean authorizableConfigBean, UserManager userManager, Session session,
             Set<String> authorizablesFromConfigurations) throws RepositoryException, AuthorizableCreatorException {
         String[] memberOf = authorizableConfigBean.getMemberOf();
-        String authorizableId = authorizableConfigBean.getAuthorizableId();
 
-        Authorizable currentGroupFromRepository = userManager.getAuthorizable(authorizableId);
+        Authorizable currentGroupFromRepository = userManager.getAuthorizable(authorizableConfigBean.getAuthorizableId());
         Set<String> membershipGroupsFromConfig = getMembershipGroupsFromConfig(memberOf);
         Set<String> membershipGroupsFromRepository = getMembershipGroupsFromRepository(currentGroupFromRepository);
 
-        applyGroupMembershipConfigIsMemberOf(authorizableId, acConfiguration, installLog, userManager, session, membershipGroupsFromConfig,
+        applyGroupMembershipConfigIsMemberOf(authorizableConfigBean, acConfiguration, installLog, userManager, session,
+                membershipGroupsFromConfig,
                 membershipGroupsFromRepository, authorizablesFromConfigurations);
     }
 
@@ -479,7 +482,7 @@ public class AuthorizableInstallerServiceImpl implements
     }
 
     @SuppressWarnings("unchecked")
-    void applyGroupMembershipConfigIsMemberOf(String authorizableId,
+    void applyGroupMembershipConfigIsMemberOf(AuthorizableConfigBean authorizableConfigBean,
             AcConfiguration acConfiguration,
             InstallationLogger installLog, UserManager userManager, Session session,
             Set<String> membershipGroupsFromConfig,
@@ -491,6 +494,7 @@ public class AuthorizableInstallerServiceImpl implements
         membershipGroupsFromConfig.remove(PRINCIPAL_EVERYONE);
         membershipGroupsFromRepository.remove(PRINCIPAL_EVERYONE);
 
+        String authorizableId = authorizableConfigBean.getAuthorizableId();
         installLog.addVerboseMessage(LOG, "Authorizable " + authorizableId + " isMemberOf(repo)=" + membershipGroupsFromRepository);
         installLog.addVerboseMessage(LOG, "Authorizable " + authorizableId + " isMemberOf(conifg)=" + membershipGroupsFromConfig);
 
@@ -508,8 +512,10 @@ public class AuthorizableInstallerServiceImpl implements
                 validatedMembershipGroupsFromConfig);
         Set<String> unmanagedMembers = new HashSet<String>();
 
-        Pattern unmanagedExternalIsMemberOfRegex = acConfiguration.getGlobalConfiguration()
-                .getDefaultUnmanagedExternalIsMemberOfRegex();
+        Pattern unmanagedExternalIsMemberOfRegex = authorizableConfigBean.getUnmanagedExternalIsMemberOfRegex();
+        if (unmanagedExternalIsMemberOfRegex == null) {
+            unmanagedExternalIsMemberOfRegex = acConfiguration.getGlobalConfiguration().getDefaultUnmanagedExternalIsMemberOfRegex();
+        }
 
         Iterator<String> toBeRemovedMembersIt = toBeRemovedMembers.iterator();
         while (toBeRemovedMembersIt.hasNext()) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizableConfigBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizableConfigBean.java
@@ -11,6 +11,7 @@ package biz.netcentric.cq.tools.actool.configmodel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -42,11 +43,14 @@ public class AuthorizableConfigBean implements AcDumpElement {
     private String migrateFrom;
 
     private String unmanagedAcePathsRegex;
+    private Pattern unmanagedExternalIsMemberOfRegex;
+    private Pattern unmanagedExternalMembersRegex;
 
     private boolean isGroup = true;
     private boolean isSystemUser = false;
 
     private String disabled;
+
 
     public String getAuthorizableId() {
         return authorizableId;
@@ -248,6 +252,22 @@ public class AuthorizableConfigBean implements AcDumpElement {
         this.unmanagedAcePathsRegex = unmanagedAcePathsRegex;
     }
 
+    public Pattern getUnmanagedExternalIsMemberOfRegex() {
+        return unmanagedExternalIsMemberOfRegex;
+    }
+
+    public void setUnmanagedExternalIsMemberOfRegex(String unmanagedExternalIsMemberOfRegex) {
+        this.unmanagedExternalIsMemberOfRegex = GlobalConfiguration.stringToRegex(unmanagedExternalIsMemberOfRegex);
+    }
+
+    public Pattern getUnmanagedExternalMembersRegex() {
+        return unmanagedExternalMembersRegex;
+    }
+
+    public void setUnmanagedExternalMembersRegex(String unmanagedExternalMembersRegex) {
+        this.unmanagedExternalMembersRegex = GlobalConfiguration.stringToRegex(unmanagedExternalMembersRegex);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
@@ -259,10 +279,11 @@ public class AuthorizableConfigBean implements AcDumpElement {
         return sb.toString();
     }
 
-    public boolean managesPath(String path) {
-        if (StringUtils.isNotBlank(unmanagedAcePathsRegex)
+    public boolean managesPath(String path, String defaultUnmanagedAcePathsRegex) {
+        String effectiveUnmanagedAcePathsRegex = StringUtils.defaultIfEmpty(unmanagedAcePathsRegex, defaultUnmanagedAcePathsRegex);
+        if (StringUtils.isNotBlank(effectiveUnmanagedAcePathsRegex)
                 && StringUtils.isNotBlank(path) /* not supporting repository permissions here */) {
-            boolean pathIsManaged = !path.matches(unmanagedAcePathsRegex);
+            boolean pathIsManaged = !path.matches(effectiveUnmanagedAcePathsRegex);
             return pathIsManaged;
         } else {
             return true; // default

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfig.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfig.java
@@ -63,12 +63,12 @@ public class AuthorizablesConfig extends LinkedHashSet<AuthorizableConfigBean> {
         return principalName;
     }
 
-    public Set<String> removeUnmanagedPrincipalNamesAtPath(String path, Set<String> principals) {
+    public Set<String> removeUnmanagedPrincipalNamesAtPath(String path, Set<String> principals, String defaultUnmanagedAcePathsRegex) {
 
         Set<String> filteredPrincipals = new HashSet<String>();
         for (String principal : principals) {
             AuthorizableConfigBean authorizableConfig = getAuthorizableConfigByPrincipalName(principal);
-            if (authorizableConfig.managesPath(path)) {
+            if (authorizableConfig.managesPath(path, defaultUnmanagedAcePathsRegex)) {
                 filteredPrincipals.add(principal);
             }
         }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/GlobalConfiguration.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/GlobalConfiguration.java
@@ -25,6 +25,7 @@ public class GlobalConfiguration {
 
     public static final String KEY_DEFAULT_UNMANAGED_EXTERNAL_ISMEMBEROF_REGEX = "defaultUnmanagedExternalIsMemberOfRegex";
     public static final String KEY_DEFAULT_UNMANAGED_EXTERNAL_MEMBERS_REGEX = "defaultUnmanagedExternalMembersRegex";
+    public static final String KEY_DEFAULT_UNMANAGED_ACE_PATHS_REGEX = "defaultUnmanagedAcePathsRegex";
 
     @Deprecated
     public static final String KEY_KEEP_EXISTING_MEMBERSHIPS_FOR_GROUP_NAMES_REGEX = "keepExistingMembershipsForGroupNamesRegEx";
@@ -34,6 +35,7 @@ public class GlobalConfiguration {
 
     private Pattern defaultUnmanagedExternalIsMemberOfRegex;
     private Pattern defaultUnmanagedExternalMembersRegex;
+    private String defaultUnmanagedAcePathsRegex;
 
     public GlobalConfiguration() {
     }
@@ -47,7 +49,9 @@ public class GlobalConfiguration {
                         + " (since v2.0.0) - please adjust your configuration.");
                 
             }
-            
+
+            setDefaultUnmanagedAcePathsRegex((String) globalConfigMap.get(KEY_DEFAULT_UNMANAGED_ACE_PATHS_REGEX));
+
             setDefaultUnmanagedExternalIsMemberOfRegex((String) globalConfigMap.get(KEY_DEFAULT_UNMANAGED_EXTERNAL_ISMEMBEROF_REGEX));
             setDefaultUnmanagedExternalMembersRegex((String) globalConfigMap.get(KEY_DEFAULT_UNMANAGED_EXTERNAL_MEMBERS_REGEX));
 
@@ -75,6 +79,13 @@ public class GlobalConfiguration {
 
     public void merge(GlobalConfiguration otherGlobalConfig) {
 
+        if (otherGlobalConfig.getDefaultUnmanagedAcePathsRegex() != null) {
+            if (defaultUnmanagedAcePathsRegex == null) {
+                defaultUnmanagedAcePathsRegex = otherGlobalConfig.getDefaultUnmanagedAcePathsRegex();
+            } else {
+                throw new IllegalArgumentException("Duplicate config for " + KEY_DEFAULT_UNMANAGED_ACE_PATHS_REGEX);
+            }
+        }
         if (otherGlobalConfig.getDefaultUnmanagedExternalIsMemberOfRegex() != null) {
             if (defaultUnmanagedExternalIsMemberOfRegex == null) {
                 defaultUnmanagedExternalIsMemberOfRegex = otherGlobalConfig.getDefaultUnmanagedExternalIsMemberOfRegex();
@@ -139,7 +150,15 @@ public class GlobalConfiguration {
         this.defaultUnmanagedExternalMembersRegex = stringToRegex(defaultUnmanagedExternalMembersRegex);
     }
 
-    private Pattern stringToRegex(String regex) {
+    public String getDefaultUnmanagedAcePathsRegex() {
+        return defaultUnmanagedAcePathsRegex;
+    }
+
+    public void setDefaultUnmanagedAcePathsRegex(String defaultUnmanagedAcePathsRegex) {
+        this.defaultUnmanagedAcePathsRegex = defaultUnmanagedAcePathsRegex;
+    }
+
+    static Pattern stringToRegex(String regex) {
         return StringUtils.isNotBlank(regex) ? Pattern.compile(regex) : null;
     }
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -70,6 +70,8 @@ public class YamlConfigReader implements ConfigReader {
     private static final String GROUP_CONFIG_PROPERTY_MIGRATE_FROM = "migrateFrom";
 
     private static final String GROUP_CONFIG_PROPERTY_UNMANAGED_ACE_PATHS_REGEX = "unmanagedAcePathsRegex";
+    private static final String GROUP_CONFIG_PROPERTY_UNMANAGED_EXTERNAL_ISMEMBEROF_REGEX = "unmanagedExternalIsMemberOfRegex";
+    private static final String GROUP_CONFIG_PROPERTY_UNMANAGED_EXTERNAL_MEMBERS_REGEX = "unmanagedExternalMembersRegex";
 
     private static final String USER_CONFIG_PROPERTY_IS_SYSTEM_USER = "isSystemUser";
 
@@ -364,6 +366,10 @@ public class YamlConfigReader implements ConfigReader {
 
         authorizableConfigBean.setUnmanagedAcePathsRegex(getMapValueAsString(currentPrincipalDataMap,
                 GROUP_CONFIG_PROPERTY_UNMANAGED_ACE_PATHS_REGEX));
+        authorizableConfigBean.setUnmanagedExternalIsMemberOfRegex(getMapValueAsString(currentPrincipalDataMap,
+                GROUP_CONFIG_PROPERTY_UNMANAGED_EXTERNAL_ISMEMBEROF_REGEX));
+        authorizableConfigBean.setUnmanagedExternalMembersRegex(getMapValueAsString(currentPrincipalDataMap,
+                GROUP_CONFIG_PROPERTY_UNMANAGED_EXTERNAL_MEMBERS_REGEX));
 
         authorizableConfigBean.setIsGroup(isGroupSection);
         authorizableConfigBean.setIsSystemUser(Boolean.valueOf(getMapValueAsString(currentPrincipalDataMap,

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
@@ -254,9 +254,9 @@ public class AcInstallationServiceImpl implements AcInstallationService, AcInsta
                 acConfiguration.getAceConfig());
 
         for (String relevantPath : relevantPathsForCleanup) {
-            // TODO: why is acconfiguration retrieved from log?
             Set<String> principalsToRemoveAcesForAtThisPath = acConfiguration.getAuthorizablesConfig()
-                    .removeUnmanagedPrincipalNamesAtPath(relevantPath, principalsInConfig);
+                    .removeUnmanagedPrincipalNamesAtPath(relevantPath, principalsInConfig,
+                            acConfiguration.getGlobalConfiguration().getDefaultUnmanagedAcePathsRegex());
 
             // delete ACE if principal *is* in config, but the path *is not* in config
             int countRemoved = AccessControlUtils.deleteAllEntriesForPrincipalsFromACL(session,

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImplTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImplTest.java
@@ -161,7 +161,11 @@ public class AuthorizableInstallerServiceImplTest {
             }).when(cut).validateAssignedGroups(userManager, acConfiguration.getAuthorizablesConfig(), null, TESTGROUP, configuredGroups, status);
 
             Set<String> authorizablesInConfig = new HashSet<String>(asList(GROUP1));
-            cut.applyGroupMembershipConfigIsMemberOf(TESTGROUP, acConfiguration, status, userManager, null, configuredGroups, groupsInRepo,
+
+            AuthorizableConfigBean authorizableConfigBean = new AuthorizableConfigBean();
+            authorizableConfigBean.setAuthorizableId(TESTGROUP);
+            cut.applyGroupMembershipConfigIsMemberOf(authorizableConfigBean, acConfiguration, status, userManager, null, configuredGroups,
+                    groupsInRepo,
                     authorizablesInConfig);
 
             verifyZeroInteractions(group2); // in configuredGroups and in groupsInRepo

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfigTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfigTest.java
@@ -1,55 +1,84 @@
 package biz.netcentric.cq.tools.actool.configmodel;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class AuthorizablesConfigTest {
 
-    @Test
-    public void testRemoveUnmanagedPrincipalNamesAtPath() {
-        AuthorizablesConfig authorizablesConfig = new AuthorizablesConfig();
+    AuthorizablesConfig authorizablesConfig;
+    AuthorizableConfigBean beanTestGroupAllManaged;
+    AuthorizableConfigBean testgroupPartlyManaged;
+    AuthorizableConfigBean beanEveryone;
 
-        AuthorizableConfigBean beanTestGroupAllManaged = getBean("testgroupAllManaged", null);
+    @Before
+    public void setup() {
+        authorizablesConfig = new AuthorizablesConfig();
+
+        beanTestGroupAllManaged = getBean("testgroupAllManaged", null);
         authorizablesConfig.add(beanTestGroupAllManaged);
 
-        AuthorizableConfigBean testgroupPartlyManaged = getBean("testgroupPartlyManaged", "/content/dam/geometrixx.*");
+        testgroupPartlyManaged = getBean("testgroupPartlyManaged", "/content/dam/geometrixx.*");
         authorizablesConfig.add(testgroupPartlyManaged);
 
         // example for negative look-ahead to only manage certain paths as useful for everyone
-        AuthorizableConfigBean beanEveryone = getBean("everyone", "^(?!/etc/linkchecker|/etc/test).*" /*
-                                                                                                       * only manage /etc/linkchecker and
-                                                                                                       * /etc/test
-                                                                                                       */ );
+        beanEveryone = getBean("everyone", "^(?!/etc/linkchecker|/etc/test).*" /*
+                                                                                * only manage /etc/linkchecker and /etc/test
+                                                                                */ );
         authorizablesConfig.add(beanEveryone);
+    }
+
+    @Test
+    public void testRemoveUnmanagedPrincipalNamesAtPath() {
 
         Set<String> principalSet = principalSet(beanTestGroupAllManaged.getPrincipalName(), testgroupPartlyManaged.getPrincipalName(),
                 beanEveryone.getPrincipalName());
 
-        Set<String> onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc/linkchecker", principalSet);
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupAllManaged"));
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupPartlyManaged"));
-        assertTrue(onlyManagedPrincipalNames.contains("everyone"));
+        Set<String> onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc/linkchecker", principalSet,
+                null);
+        assertEquals(principalSet("testgroupAllManaged", "testgroupPartlyManaged", "everyone"), onlyManagedPrincipalNames);
 
-        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc", principalSet);
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupAllManaged"));
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupPartlyManaged"));
-        assertFalse(onlyManagedPrincipalNames.contains("everyone"));
+        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc", principalSet, null);
+        assertEquals(principalSet("testgroupAllManaged", "testgroupPartlyManaged"), onlyManagedPrincipalNames);
 
-        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/geometrixx", principalSet);
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupAllManaged"));
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupPartlyManaged"));
-        assertFalse(onlyManagedPrincipalNames.contains("everyone"));
+        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/geometrixx", principalSet, null);
+        assertEquals(principalSet("testgroupAllManaged", "testgroupPartlyManaged"), onlyManagedPrincipalNames);
 
-        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/dam/geometrixx", principalSet);
-        assertTrue(onlyManagedPrincipalNames.contains("testgroupAllManaged"));
-        assertFalse(onlyManagedPrincipalNames.contains("testgroupPartlyManaged"));
-        assertFalse(onlyManagedPrincipalNames.contains("everyone"));
+        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/dam/geometrixx", principalSet, null);
+        assertEquals(principalSet("testgroupAllManaged"), onlyManagedPrincipalNames);
+
+    }
+
+    @Test
+    public void testRemoveUnmanagedPrincipalNamesAtPathUsingGlobalConfig() {
+
+        Set<String> principalSet = principalSet(beanTestGroupAllManaged.getPrincipalName(), testgroupPartlyManaged.getPrincipalName(),
+                beanEveryone.getPrincipalName());
+
+        Set<String> onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc/linkchecker", principalSet,
+                "/etc/.*");
+
+        // "testgroupPartlyManaged", "everyone" are still in since they define their own unmanagedAcePathsRegex
+        assertEquals(principalSet("testgroupPartlyManaged", "everyone"), onlyManagedPrincipalNames);
+
+        // without any individual unmanagedAcePathsRegex set but defaultUnmanagedAcePathsRegex set to a matching regex, there will be never
+        // anything removed from this path
+        testgroupPartlyManaged.setUnmanagedAcePathsRegex(null);
+        beanEveryone.setUnmanagedAcePathsRegex(null);
+        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc/linkchecker", principalSet,
+                "/etc/.*");
+        assertEquals(Collections.emptySet(), onlyManagedPrincipalNames);
+
+        // without default restriction all principals have to be returned
+        onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/etc/linkchecker", principalSet,
+                null);
+        assertEquals(principalSet("testgroupAllManaged", "testgroupPartlyManaged", "everyone"), onlyManagedPrincipalNames);
 
     }
 

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -198,6 +198,8 @@ The AC Tool manages relationships between authorizables of the configuration (th
 
 That way relationships that are created programmatically or manually can be left intact and the AC Tool does not remove them. Also this allows to have two configuration sets at different root paths.
 
+Additionally, it is also possible to set `unmanagedExternalIsMemberOfRegex` and `unmanagedExternalMembersRegex` directly on the authorizable definition (then only effective locally to the authorizable).
+
 ### Examples ###
 
 * `defaultUnmanagedExternalMembersRegex: .*` allow arbitrary groups to inherit from ACTool managed groups and keep those (unmanaged) relations even though relationship hasn't been established through the ACTool. Might be useful in a multi-tenant setup where each tenant maintains his own list of groups (e.g. via ACTool in dedicated packages) and wants to inherit from some fragments being set up by the global YAML file.
@@ -205,7 +207,7 @@ That way relationships that are created programmatically or manually can be left
 
 ## Limiting where the AC Tool creates and removes ACEs
 
-The property `unmanagedAcePathsRegex` for authorizable configurations (users or groups) can be used to ensure certain paths are not managed by the AC Tool. This property must contain a regular expression which is matched against all ACE paths bound to the authorizable found in the system. All ACEs with matching paths are not touched:
+The property `unmanagedAcePathsRegex` for authorizable configurations (users or groups) can be used to ensure certain paths are not managed by the AC Tool. This property must contain a regular expression which is matched against all ACE paths bound to the authorizable found in the system. All ACEs with matching paths are not touched. By setting the global config `defaultUnmanagedAcePathsRegex` it is possible to exclude certain areas of the JCR totally from removing (and creating once #244 is fixed) at all.
 
 ### Examples
 ```
@@ -225,6 +227,12 @@ You can use negative lookaheads to whitelist management of certain paths:
       isSystemUser: true
    # everything outside /conf should not be managed by the ac tool
       unmanagedAcePathsRegex: /(?!conf).*
+```
+
+Example for setting it globally:
+```
+- global_config:
+      defaultUnmanagedAcePathsRegex: /content/project2.* # will never change any ACLs underneath this root path 
 ```
 
 ## Automatically purge obsolete groups and users


### PR DESCRIPTION
#269 Adding config properties unmanagedExternalIsMemberOfRegex and unmanagedExternalMembersRegex to authorizable config and
defaultUnmanagedAcePathsRegex to globa config