### PR TITLE
#290 Fix NPE in removeUmmanagedPrincipals

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfig.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfig.java
@@ -68,7 +68,7 @@ public class AuthorizablesConfig extends LinkedHashSet<AuthorizableConfigBean> {
         Set<String> filteredPrincipals = new HashSet<String>();
         for (String principal : principals) {
             AuthorizableConfigBean authorizableConfig = getAuthorizableConfigByPrincipalName(principal);
-            if (authorizableConfig.managesPath(path, defaultUnmanagedAcePathsRegex)) {
+            if (authorizableConfig == null || authorizableConfig.managesPath(path, defaultUnmanagedAcePathsRegex)) {
                 filteredPrincipals.add(principal);
             }
         }

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfigTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configmodel/AuthorizablesConfigTest.java
@@ -52,7 +52,16 @@ public class AuthorizablesConfigTest {
 
         onlyManagedPrincipalNames = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/dam/geometrixx", principalSet, null);
         assertEquals(principalSet("testgroupAllManaged"), onlyManagedPrincipalNames);
+    }
 
+    @Test
+    public void testRemoveUnmanagedPrincipalNamesAtPathWithNoAutorizableBean() {
+        //We add a new non-existant name to remove but that doesn't belong in the authorizables list
+        Set<String> principalSet = principalSet(beanTestGroupAllManaged.getPrincipalName(), testgroupPartlyManaged.getPrincipalName(),
+                beanEveryone.getPrincipalName(), "nonExistentPrincipal");
+
+        Set<String> removedPrincipals = authorizablesConfig.removeUnmanagedPrincipalNamesAtPath("/content/dam/geometrixx", principalSet, null);
+        assertEquals(principalSet("testgroupAllManaged", "nonExistentPrincipal"), removedPrincipals);
     }
 
     @Test


### PR DESCRIPTION
AuthorizablesConfig holds a set of AuthorizableConfigBean and exposes a method to get which principals could be removed for a given path.

When a non-existant name is included in that principal's list the method is throwing a NullPointerException.

Adding a null check will also include that given principal's name to the list of principals to be removed

Closed #290