### PR TITLE
Skip getting/managing members of the built-in "everyone" group

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
@@ -99,6 +99,7 @@ public class AuthorizableInstallerServiceImpl implements
             AuthorizableExistsException, AuthorizableCreatorException, CryptoException {
 
         String authorizableId = authorizableConfigBean.getAuthorizableId();
+        boolean authorizableIsEveryone = StringUtils.equals(authorizableId, PRINCIPAL_EVERYONE);
         LOG.debug("- start installation of authorizable: {}", authorizableId);
 
         UserManager userManager = AccessControlUtils.getUserManagerAutoSaveDisabled(session);
@@ -122,11 +123,15 @@ public class AuthorizableInstallerServiceImpl implements
             // move authorizable if path changed (retaining existing members)
             handleRecreationOfAuthorizableIfNecessary(session, acConfiguration, authorizableConfigBean, installLog, userManager);
 
-            applyGroupMembershipConfigIsMemberOf(installLog, acConfiguration, authorizableConfigBean, userManager, session, authorizablesFromConfigurations);
+            if (!authorizableIsEveryone) {
+                applyGroupMembershipConfigIsMemberOf(installLog, acConfiguration, authorizableConfigBean, userManager, session, authorizablesFromConfigurations);
+            }
 
         }
 
-        applyGroupMembershipConfigMembers(acConfiguration, authorizableConfigBean, installLog, authorizableId, userManager, authorizablesFromConfigurations);
+        if (!authorizableIsEveryone) {
+            applyGroupMembershipConfigMembers(acConfiguration, authorizableConfigBean, installLog, authorizableId, userManager, authorizablesFromConfigurations);
+        }
 
         if (StringUtils.isNotBlank(authorizableConfigBean.getMigrateFrom()) && authorizableConfigBean.isGroup()) {
             migrateFromOldGroup(authorizableConfigBean, userManager, installLog);


### PR DESCRIPTION
If one needs to set some ACLs for the everyone group it has to be redefined - example:
```
  - everyone:
    - path: /home/groups/e
      # everything outside the given paths should not be managed by the ac tool
      unmanagedAcePathsRegex: ^(?!(/libs/social/console/content/sites|/libs/cq/core/content/nav/communities/sites)).*$
```
but the everyone group is a special group that has be definition no members (any user is implicitly member of it).

the AC tool handles it as every other group, iterating over all existing members to check if any changes are necessary.

and if a lot of users are installed on the system (e.g. 100,000 users) it takes a considerable amount of time to iterate through all of them, although it makes not sense at all because the members of everyone cannot be changed.

this simple PR avoids this by adding some condition checks. maybe there is more special handling needed for the everyone group, but this change mitigates the described performance problem.