### PR TITLE
Could not decrypt password for user (CryptoSupport missing to unprotect password.)

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
@@ -70,7 +70,7 @@ public class AuthorizableInstallerServiceImpl implements
     ExternalGroupInstallerServiceImpl externalGroupCreatorService;
 
     @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy=ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
-    CryptoSupport cryptoSupport;
+    volatile CryptoSupport cryptoSupport;
 
     @Override
     public void installAuthorizables(


### PR DESCRIPTION
An exception is thrown on fresh AEM 6.4 with just AC Tool installed and according to web console `cryptoSupport` is satisfied:

```
ERROR: Could not process yaml files / e=biz.netcentric.cq.tools.actool.authorizableinstaller.AuthorizableCreatorException: biz.netcentric.cq.tools.actool.authorizableinstaller.AuthorizableCreatorException: Could not decrypt password for user [...]: com.adobe.granite.crypto.CryptoException: CryptoSupport missing to unprotect password.
```

```
Bundle | biz.netcentric.cq.tools.accesscontroltool.bundle (545)
-- | --
Implementation Class | biz.netcentric.cq.tools.actool.authorizableinstaller.impl.AuthorizableInstallerServiceImpl
Default State | enabled
Activation | delayed
Configuration Policy | optional
Service Type | singleton
Services | biz.netcentric.cq.tools.actool.authorizableinstaller.AuthorizableInstallerService
PID | biz.netcentric.cq.tools.actool.authorizableinstaller.impl.AuthorizableInstallerServiceImpl
Reference cryptoSupport | SatisfiedService Name: com.adobe.granite.crypto.CryptoSupportCardinality: 0..1Policy: dynamicPolicy Option: greedyBound Service ID 36
Reference externalGroupCreatorService | SatisfiedService Name: biz.netcentric.cq.tools.actool.authorizableinstaller.impl.ExternalGroupInstallerServiceImplCardinality: 0..1Policy: staticPolicy Option: greedyBound Service ID 7059 (biz.netcentric.cq.tools.actool.authorizableinstaller.impl.ExternalGroupInstallerServiceImpl)
Properties | component.id = 3245component.name = biz.netcentric.cq.tools.actool.authorizableinstaller.impl.AuthorizableInstallerServiceImpl
```