### PR TITLE
Avoid to get declared members twices for huge groups

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
@@ -234,16 +234,19 @@ public class AuthorizableInstallerServiceImpl implements
             String memberId = relevantMembersIt.next();
             Authorizable member = userManager.getAuthorizable(memberId);
 
-            if (member != null && !member.isGroup() // if user
-                    && !member.getPath().startsWith(Constants.USERS_ROOT + "/system/") // but not system user
-                    && !member.getID().equals(Constants.USER_ANONYMOUS) // and not anonymous
-            ) {
+            if (isRegularUser(member)) {
                 // not relevant for further handling
                 relevantMembersIt.remove();
             }
         }
 
         return relevantMembers;
+    }
+
+    private boolean isRegularUser(Authorizable member) throws RepositoryException {
+      return member != null && !member.isGroup() // if user
+          && !member.getPath().startsWith(Constants.USERS_ROOT + "/system/") // but not system user
+          && !member.getID().equals(Constants.USER_ANONYMOUS);  // and not anonymous
     }
 
     private Set<String> removeExternalMembersUnmanagedByConfiguration(AcConfiguration acConfiguration, AuthorizableConfigBean authorizableConfigBean,
@@ -281,7 +284,10 @@ public class AuthorizableInstallerServiceImpl implements
         Set<String> membersInRepo = new HashSet<String>();
         Iterator<Authorizable> currentMemberInRepo = installedGroup.getDeclaredMembers();
         while (currentMemberInRepo.hasNext()) {
-            membersInRepo.add(currentMemberInRepo.next().getID());
+            Authorizable member = currentMemberInRepo.next();
+            if (!isRegularUser(member)) {
+                membersInRepo.add(member.getID());
+            }
         }
         return membersInRepo;
     }


### PR DESCRIPTION
Scenario: We have a group with 80000 members (as a starting point, more in the future).
The group itself and all other groups in the system are maintained via ACTool.

problem: when this group is processed, the ACtool processing pauses for several minutes at this groups. looking into the code we detected that those 80000 users are fetched twice - first as part of all declared members, second again to filter out the regular users of the declared members.

this PR optimizes the code path again to filter out the regular users in the first place. i'm not sure if it was by intention that this fetching took place twice, please cross-check.