### PR TITLE
370: removing trailing slashes while reading the configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 # standard maven build with travis
 language: java
 jdk: oraclejdk8
+# fixing  broken build, see https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/7
+dist: trusty

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -300,9 +300,7 @@ public class YamlConfigReader implements ConfigReader {
                                                   // AcConfiguration.ensureAceBeansHaveCorrectPrincipalNameSet()
 
         String jcrPath = getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PATH);
-        String cleanJcrPath =  StringUtils.removeEnd(jcrPath, "/");
-        LOG.debug("cleaned jcr path: {} to {}", jcrPath, cleanJcrPath);
-        aclBean.setJcrPath(cleanJcrPath);
+        aclBean.setJcrPath(StringUtils.removeEnd(jcrPath, "/"));
 
         aclBean.setPrivilegesString(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PRIVILEGES));
         aclBean.setPermission(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PERMISSION));

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -293,31 +293,26 @@ public class YamlConfigReader implements ConfigReader {
         return new AuthorizableConfigBean();
     }
 
-    protected void setupAceBean(final String authorizableId,
-            final Map<String, ?> currentAceDefinition, final AceBean aclBean) {
+    protected void setupAceBean(final String authorizableId, final Map<String, ?> currentAceDefinition, final AceBean aclBean) {
 
         aclBean.setAuthorizableId(authorizableId);
         aclBean.setPrincipalName(authorizableId); // to ensure it is set, later corrected if necessary in
                                                   // AcConfiguration.ensureAceBeansHaveCorrectPrincipalNameSet()
 
-        aclBean.setJcrPath(getMapValueAsString(currentAceDefinition,
-                ACE_CONFIG_PROPERTY_PATH));
+        String jcrPath = getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PATH);
+        String cleanJcrPath =  StringUtils.removeEnd(jcrPath, "/");
+        LOG.debug("cleaned jcr path: {} to {}", jcrPath, cleanJcrPath);
+        aclBean.setJcrPath(cleanJcrPath);
 
-        aclBean.setPrivilegesString(getMapValueAsString(
-                currentAceDefinition, ACE_CONFIG_PROPERTY_PRIVILEGES));
-        aclBean.setPermission(getMapValueAsString(
-                currentAceDefinition, ACE_CONFIG_PROPERTY_PERMISSION));
+        aclBean.setPrivilegesString(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PRIVILEGES));
+        aclBean.setPermission(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_PERMISSION));
 
-        aclBean.setRestrictions(currentAceDefinition.get(ACE_CONFIG_PROPERTY_RESTRICTIONS),
-                (String) currentAceDefinition.get(ACE_CONFIG_PROPERTY_GLOB));
-        aclBean.setActions(parseActionsString(getMapValueAsString(currentAceDefinition,
-                ACE_CONFIG_PROPERTY_ACTIONS)));
+        aclBean.setRestrictions(currentAceDefinition.get(ACE_CONFIG_PROPERTY_RESTRICTIONS),(String) currentAceDefinition.get(ACE_CONFIG_PROPERTY_GLOB));
+        aclBean.setActions(parseActionsString(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_ACTIONS)));
 
-        aclBean.setKeepOrder(Boolean.valueOf(getMapValueAsString(currentAceDefinition,
-                ACE_CONFIG_PROPERTY_KEEP_ORDER)));
+        aclBean.setKeepOrder(Boolean.valueOf(getMapValueAsString(currentAceDefinition, ACE_CONFIG_PROPERTY_KEEP_ORDER)));
 
-        String initialContent = getMapValueAsString(currentAceDefinition,
-                ACE_CONFIG_INITIAL_CONTENT);
+        String initialContent = getMapValueAsString(currentAceDefinition, ACE_CONFIG_INITIAL_CONTENT);
         aclBean.setInitialContent(initialContent);
     }
 

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
@@ -71,7 +71,15 @@ public class YamlConfigReaderTest {
         final ConfigReader yamlConfigReader = new YamlConfigReader();
         final List<LinkedHashMap> yamlList = getYamlList("test-multiple-aces-same-path.yaml");
         final AcesConfig acls = yamlConfigReader.getAceConfigurationBeans(yamlList, null, session);
+
         assertEquals("Number of ACLs", 3, acls.filterByAuthorizableId("groupA").size());
+        assertEquals("Number of ACLs", 2, acls.filterByAuthorizableId("groupB").size());
+
+        Iterator<AceBean> iterator = acls.iterator();
+        while (iterator.hasNext()) {
+            AceBean aceBean = iterator.next();
+            assertEquals("/content", aceBean.getJcrPath());
+        }
     }
 
     @Test

--- a/accesscontroltool-bundle/src/test/resources/test-multiple-aces-same-path.yaml
+++ b/accesscontroltool-bundle/src/test/resources/test-multiple-aces-same-path.yaml
@@ -14,11 +14,17 @@
          isMemberOf: 
          path: /home/groups/g
          
+    - groupB:
+
+        - name:
+          isMemberOf:
+          path: /home/groups/g
+
 - ace_config:
     
     - groupA:
     
-        - path: /content
+        - path: /content/
           permission: deny
           actions: read,acl_read
           privileges:
@@ -35,3 +41,17 @@
           actions: read,acl_read
           privileges:
           repGlob: /jcr:content*
+
+    - groupB:
+
+        - path: /content
+          permission: deny
+          actions: read,acl_read
+          privileges:
+          repGlob:
+
+        - path: /content
+          permission: allow
+          actions: read,acl_read
+          privileges:
+          repGlob: ""


### PR DESCRIPTION
the Pull Request contains the following changes:

- the proposal to cleanup the trailing slashes when reading the config
- an extended unit test, which will ensure, that all path's are the same
- an extended yaml file