### PR TITLE
Fix tag paths in examples to use '/content/cq:tags'

### DIFF
--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/multipleFiles/testgroups/testgroup.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/multipleFiles/testgroups/testgroup.yaml
@@ -11,7 +11,7 @@
 
     - testgroup-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/multipleFiles/testgroups/testgroup2.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/multipleFiles/testgroups/testgroup2.yaml
@@ -11,7 +11,7 @@
 
     - testgroup2-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/global.author/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/global.author/config.yaml
@@ -34,7 +34,7 @@
          actions: read,modify,create,delete,acl_read,replicate
          privileges: 
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read,modify,create,delete,acl_read,replicate
          privileges: 
@@ -74,7 +74,7 @@
          actions: read,modify,create,delete,acl_read,replicate
          privileges: 
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read,modify,create,delete,acl_read,replicate
          privileges: 
@@ -96,7 +96,7 @@
          actions: read,acl_read
          privileges: 
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read,acl_read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/serviceuser.author/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/serviceuser.author/config.yaml
@@ -27,7 +27,7 @@
 
     - system-user-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/system.author/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/realProject/system.author/config.yaml
@@ -161,19 +161,19 @@
          privileges: jcr:read,jcr:readAccessControl
          repGlob: /jcr:*
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: deny
          actions: 
          privileges: jcr:read,jcr:readAccessControl
          repGlob: 
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: 
          privileges: jcr:read,jcr:readAccessControl
          repGlob: ""
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: 
          privileges: jcr:read,jcr:readAccessControl

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/runmodes/testgroup.author/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/runmodes/testgroup.author/config.yaml
@@ -11,7 +11,7 @@
 
     - testgroup-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/runmodes/testgroup2.author.dev,author.test/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/runmodes/testgroup2.author.dev,author.test/config.yaml
@@ -11,7 +11,7 @@
 
     - testgroup2-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/simple/testgroup/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/simple/testgroup/config.yaml
@@ -11,7 +11,7 @@
 
     - testgroup-tags:
 
-       - path: /etc/tags
+       - path: /content/cq:tags
          permission: allow
          actions: read
          privileges: 


### PR DESCRIPTION
Title says it all
related issue: #375 