### PR TITLE
Support for custom Oak privileges

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/PrivilegeInstaller.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/PrivilegeInstaller.java
@@ -1,0 +1,21 @@
+/*
+ * (C) Copyright 2015 Netcentric AG.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package biz.netcentric.cq.tools.actool.authorizableinstaller;
+
+import biz.netcentric.cq.tools.actool.configmodel.PrivilegeConfig;
+import biz.netcentric.cq.tools.actool.history.InstallationLogger;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+public interface PrivilegeInstaller {
+
+    void installPrivileges(PrivilegeConfig config, Session session, InstallationLogger installLog)
+            throws RepositoryException;
+}

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/PrivilegeInstallerImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/PrivilegeInstallerImpl.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright 2015 Netcentric AG.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package biz.netcentric.cq.tools.actool.authorizableinstaller.impl;
+
+import biz.netcentric.cq.tools.actool.authorizableinstaller.PrivilegeInstaller;
+import biz.netcentric.cq.tools.actool.configmodel.PrivilegeBean;
+import biz.netcentric.cq.tools.actool.configmodel.PrivilegeConfig;
+import biz.netcentric.cq.tools.actool.history.InstallationLogger;
+import org.apache.jackrabbit.api.JackrabbitWorkspace;
+import org.apache.jackrabbit.api.security.authorization.PrivilegeManager;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.lang.invoke.MethodHandles;
+
+@Component
+public class PrivilegeInstallerImpl implements PrivilegeInstaller {
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @Override
+    public void installPrivileges(PrivilegeConfig config, Session session, InstallationLogger installLog) throws RepositoryException {
+        PrivilegeManager privilegeManager = ((JackrabbitWorkspace) session.getWorkspace()).getPrivilegeManager();
+        for (PrivilegeBean privilege : config) {
+            String privilegeName = privilege.getPrivilegeName();
+            try {
+                privilegeManager.registerPrivilege(
+                        privilegeName,
+                        privilege.isAbstract(),
+                        privilege.getAggregateNames());
+                installLog.addMessage(LOG, "created " + privilegeName);
+            } catch (RepositoryException e) {
+                String alreadyExistsMsg = "Privilege definition with name '" + privilegeName + "' already exists.";
+                if (alreadyExistsMsg.equals(e.getMessage())) {
+                    installLog.addMessage(LOG, alreadyExistsMsg);
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+    }
+}

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AcConfiguration.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AcConfiguration.java
@@ -33,6 +33,8 @@ public class AcConfiguration {
 
     private Set<String> obsoleteAuthorizables = new HashSet<String>();
 
+    private PrivilegeConfig privilegeConfiguration;
+
     private List<AuthorizableConfigBean> virtualGroups = new ArrayList<AuthorizableConfigBean>();
 
     public GlobalConfiguration getGlobalConfiguration() {
@@ -58,6 +60,15 @@ public class AcConfiguration {
     public void setAceConfig(AcesConfig aceBeansSet) {
         this.aceBeansConfig = aceBeansSet;
         ensureAceBeansHaveCorrectPrincipalNameSet();
+    }
+
+
+    public PrivilegeConfig getPrivilegeConfig() {
+        return privilegeConfiguration;
+    }
+
+    public void setPrivilegeConfig(PrivilegeConfig cfg){
+        privilegeConfiguration = cfg;
     }
 
     // this is required as the configuration contains authorizableIds, but the JCR contains principal names. The mapping is available via

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/PrivilegeBean.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/PrivilegeBean.java
@@ -1,0 +1,92 @@
+/*
+ * (C) Copyright 2015 Netcentric AG.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package biz.netcentric.cq.tools.actool.configmodel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/**
+ * Bean representation of {@link javax.jcr.security.Privilege}
+ */
+public class PrivilegeBean {
+
+    public static final Logger LOG = LoggerFactory.getLogger(PrivilegeBean.class);
+
+    private String privilegeName;
+    private boolean isAbstract;
+    private String[] aggregateNames = {};
+
+    /**
+     * The name of the privilege.
+     * Corresponds to the node name under /jcr:system/rep:privileges,
+     * e.g. /jcr:system/rep:privileges/sling:feature
+     */
+    public String getPrivilegeName() {
+        return privilegeName;
+    }
+
+    public void setPrivilegeName(String privilegeName) {
+        this.privilegeName = privilegeName;
+    }
+
+    /**
+     * @return <code>true</code> if this privilege is an abstract privilege;
+     *         <code>false</code> otherwise.
+     */
+    public boolean isAbstract() {
+        return isAbstract;
+    }
+
+    public void setAbstract(boolean anAbstract) {
+        isAbstract = anAbstract;
+    }
+
+    /**
+     * If this privilege is an aggregate privilege, returns the names of the
+     * directly contained privileges. Otherwise returns an empty
+     * array.
+     *
+     * @return an array of aggregate names
+     */
+    public String[] getAggregateNames() {
+        return aggregateNames;
+    }
+
+    public void setAggregateNames(String[] aggregateNames) {
+        this.aggregateNames = aggregateNames;
+    }
+
+    @Override
+    public PrivilegeBean clone() {
+
+        PrivilegeBean clone = new PrivilegeBean();
+        clone.setAbstract(isAbstract);
+        clone.setAggregateNames(aggregateNames);
+        clone.setPrivilegeName(privilegeName);
+        return clone;
+
+    }
+
+    // privileges are equal by name
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PrivilegeBean that = (PrivilegeBean) o;
+        return privilegeName.equals(that.privilegeName);
+    }
+
+    // privileges are equal by name
+    @Override
+    public int hashCode() {
+        return Objects.hash(privilegeName);
+    }
+}

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/PrivilegeConfig.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/PrivilegeConfig.java
@@ -1,0 +1,26 @@
+/*
+ * (C) Copyright 2017 Netcentric AG.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package biz.netcentric.cq.tools.actool.configmodel;
+
+import java.util.LinkedHashSet;
+
+public class PrivilegeConfig extends LinkedHashSet<PrivilegeBean> {
+    private static final long serialVersionUID = -153685832563296002L;
+
+
+    public void merge(PrivilegeConfig otherConfig) {
+        for(PrivilegeBean bean : otherConfig){
+            if(contains(bean)){
+                throw new IllegalArgumentException("Duplicate privilege configuration for " + bean.getPrivilegeName());
+            } else {
+                add(bean);
+            }
+        }
+    }
+}

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/ConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/ConfigReader.java
@@ -17,6 +17,7 @@ import javax.jcr.Session;
 import biz.netcentric.cq.tools.actool.configmodel.AcesConfig;
 import biz.netcentric.cq.tools.actool.configmodel.AuthorizablesConfig;
 import biz.netcentric.cq.tools.actool.configmodel.GlobalConfiguration;
+import biz.netcentric.cq.tools.actool.configmodel.PrivilegeConfig;
 import biz.netcentric.cq.tools.actool.validators.AceBeanValidator;
 import biz.netcentric.cq.tools.actool.validators.AuthorizableValidator;
 import biz.netcentric.cq.tools.actool.validators.exceptions.AcConfigBeanValidationException;
@@ -40,5 +41,7 @@ public interface ConfigReader {
     public GlobalConfiguration getGlobalConfiguration(final Collection yamlList);
 
     public Set<String> getObsoluteAuthorizables(Collection yamlList);
+
+    PrivilegeConfig getPrivilegeConfiguration(Collection yamlList);
 
 }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/Constants.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
     public static final String GROUP_CONFIGURATION_KEY = "group_config";
     public static final String USER_CONFIGURATION_KEY = "user_config";
     public static final String ACE_CONFIGURATION_KEY = "ace_config";
+    public static final String PRIVILEGE_CONFIGURATION_KEY = "privilege_config";
 
     public static final String OBSOLETE_AUTHORIZABLES_KEY = "obsolete_authorizables";
 
@@ -30,7 +31,8 @@ public class Constants {
             GROUP_CONFIGURATION_KEY,
             USER_CONFIGURATION_KEY,
             ACE_CONFIGURATION_KEY,
-            OBSOLETE_AUTHORIZABLES_KEY));
+            OBSOLETE_AUTHORIZABLES_KEY,
+            PRIVILEGE_CONFIGURATION_KEY));
 
     public static final String USER_ANONYMOUS = "anonymous";
     public static final String USER_AC_SERVICE = "actool";

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcInstallationServiceImpl.java
@@ -29,6 +29,8 @@ import javax.jcr.Session;
 import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.ValueFormatException;
 
+import biz.netcentric.cq.tools.actool.authorizableinstaller.PrivilegeInstaller;
+import biz.netcentric.cq.tools.actool.configmodel.*;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.StopWatch;
@@ -56,11 +58,6 @@ import biz.netcentric.cq.tools.actool.api.AcInstallationService;
 import biz.netcentric.cq.tools.actool.api.InstallationLog;
 import biz.netcentric.cq.tools.actool.authorizableinstaller.AuthorizableCreatorException;
 import biz.netcentric.cq.tools.actool.authorizableinstaller.AuthorizableInstallerService;
-import biz.netcentric.cq.tools.actool.configmodel.AcConfiguration;
-import biz.netcentric.cq.tools.actool.configmodel.AceBean;
-import biz.netcentric.cq.tools.actool.configmodel.AcesConfig;
-import biz.netcentric.cq.tools.actool.configmodel.AuthorizableConfigBean;
-import biz.netcentric.cq.tools.actool.configmodel.AuthorizablesConfig;
 import biz.netcentric.cq.tools.actool.configreader.ConfigFilesRetriever;
 import biz.netcentric.cq.tools.actool.configreader.ConfigReader;
 import biz.netcentric.cq.tools.actool.configreader.ConfigurationMerger;
@@ -116,6 +113,9 @@ public class AcInstallationServiceImpl implements AcInstallationService, AcInsta
 
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
     private ConfigurationAdmin configAdmin;
+
+    @Reference(policyOption = ReferencePolicyOption.GREEDY)
+    PrivilegeInstaller privilegeInstaller;
 
     private String configuredAcConfigurationRootPath;
 
@@ -468,7 +468,12 @@ public class AcInstallationServiceImpl implements AcInstallationService, AcInsta
         AuthorizablesConfig authorizablesConfig = acConfiguration.getAuthorizablesConfig();
         installLog.addMessage(LOG, "*** Starting installation of " + authorizablesConfig.size() + " authorizables from configuration...");
 
+        PrivilegeConfig privilegesConfig = acConfiguration.getPrivilegeConfig();
         try {
+            if(privilegesConfig != null) {
+                privilegeInstaller.installPrivileges(privilegesConfig, session, installLog);
+            }
+
             // only save session if no exceptions occurred
             authorizableCreatorService.installAuthorizables(acConfiguration, authorizablesConfig, session, installLog);
 

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
@@ -12,6 +12,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
@@ -25,15 +27,13 @@ import java.util.Set;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import biz.netcentric.cq.tools.actool.configmodel.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.yaml.snakeyaml.Yaml;
 
-import biz.netcentric.cq.tools.actool.configmodel.AceBean;
-import biz.netcentric.cq.tools.actool.configmodel.AcesConfig;
-import biz.netcentric.cq.tools.actool.configmodel.AuthorizableConfigBean;
 import biz.netcentric.cq.tools.actool.validators.exceptions.AcConfigBeanValidationException;
 
 public class YamlConfigReaderTest {
@@ -128,6 +128,35 @@ public class YamlConfigReaderTest {
         assertEquals("groupB", secondGroup.getAuthorizableId());
         assertArrayEquals(new String[] {"groupA"}, secondGroup.getMembers());
 
+    }
+
+    @Test
+    public void testPrivileges() throws IOException {
+        ConfigReader yamlConfigReader = new YamlConfigReader();
+        List<Map> yamlList = getYamlList("test-privileges.yaml");
+        PrivilegeConfig config = yamlConfigReader.getPrivilegeConfiguration(yamlList);
+        assertEquals("Number of privileges", 4, config.size());
+
+        Iterator<PrivilegeBean> it = config.iterator();
+        PrivilegeBean bean1 = it.next();
+        assertEquals("sling:feature", bean1.getPrivilegeName());
+        assertFalse(bean1.isAbstract());
+        assertArrayEquals(new String[0], bean1.getAggregateNames());
+
+        PrivilegeBean bean2 = it.next();
+        assertEquals("cq:doThis", bean2.getPrivilegeName());
+        assertFalse(bean2.isAbstract());
+        assertArrayEquals(new String[0], bean2.getAggregateNames());
+
+        PrivilegeBean bean3 = it.next();
+        assertEquals("cq:doThat", bean3.getPrivilegeName());
+        assertTrue(bean3.isAbstract());
+        assertArrayEquals(new String[0], bean3.getAggregateNames());
+
+        PrivilegeBean bean4 = it.next();
+        assertEquals("cq:doThese", bean4.getPrivilegeName());
+        assertFalse(bean4.isAbstract());
+        assertArrayEquals(new String[]{"jcr:read", "jcr:write"}, bean4.getAggregateNames());
     }
 
     static List<Map> getYamlList(final String filename) throws IOException {

--- a/accesscontroltool-bundle/src/test/resources/test-merge-privileges-a.yaml
+++ b/accesscontroltool-bundle/src/test/resources/test-merge-privileges-a.yaml
@@ -1,0 +1,4 @@
+- privilege_config:
+
+    - sling:feature1:
+

--- a/accesscontroltool-bundle/src/test/resources/test-merge-privileges-b.yaml
+++ b/accesscontroltool-bundle/src/test/resources/test-merge-privileges-b.yaml
@@ -1,0 +1,5 @@
+- privilege_config:
+
+    - sling:feature2:
+        - isAbstract: true
+

--- a/accesscontroltool-bundle/src/test/resources/test-privileges.yaml
+++ b/accesscontroltool-bundle/src/test/resources/test-privileges.yaml
@@ -1,0 +1,16 @@
+- privilege_config:
+
+    - sling:feature:
+
+    - cq:doThis:
+        - isAbstract: false
+          name: cq:doThis
+          declaredAggregateNames:
+
+    - cq:doThat:
+        - isAbstract: true
+
+    - doThese:
+        - isAbstract: false
+          name: cq:doThese
+          declaredAggregateNames: jcr:read,jcr:write

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/customPrivileges/Readme.md
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/customPrivileges/Readme.md
@@ -1,0 +1,1 @@
+Registers custom Oak privileges and uses them in the ACE configurations.

--- a/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/customPrivileges/config.yaml
+++ b/accesscontroltool-exampleconfig-package/src/main/jcr_root/apps/netcentric/actool-exampleconfig/customPrivileges/config.yaml
@@ -1,0 +1,25 @@
+- privilege_config:
+
+    - sling:feature:
+
+    - sling:anotherFeature:
+        - isAbstract: false
+          declaredAggregateNames: jcr:read,jcr:write
+
+
+- group_config:
+
+    - sling-feature-users:
+        - name:
+
+- ace_config:
+
+    - sling-feature-users:
+
+        - path: /content
+          permission: allow
+          privileges: sling:feature
+
+        - path: /content/dam
+          permission: allow
+          privileges: sling:anotherFeature

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -386,3 +386,32 @@ NOTE: This is never necessary when using TarMK and also it should only be used f
 
 [i257]: https://github.com/Netcentric/accesscontroltool/issues/257
 
+## Custom Privileges
+
+Since v2.3.3 you can register custom Oak privileges and grant it in your ACL configurations: 
+
+```
+- privilege_config:
+    # register a custom privilege
+    - sling:feature:
+
+- group_config:
+
+    - sling-feature-users:
+        - name:
+
+- ace_config:
+
+    - sling-feature-users:
+
+        - path: /content
+          permission: allow
+          privileges: sling:feature
+```
+The _privilege_config_ block is evaluated before all ACE configurations and can contain the following properties:
+
+property | comment | required
+--- | --- | ---
+name | The name of the privilege. Corresponds to the node name under `/jcr:system/rep:privileges/*`, e.g. the name `sling:feature` will corresepnd to `/jcr:system/rep:privileges/sling:feature` | no. defaults to the yaml key if not set or empty
+isAbstract | whether this privilege is abstract | no. default is `false`
+declaredAggregateNames | Comma-separated names of the directly contained privileges | no

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -388,7 +388,7 @@ NOTE: This is never necessary when using TarMK and also it should only be used f
 
 ## Custom Privileges
 
-Since v2.3.3 you can register custom Oak privileges and grant it in your ACL configurations: 
+Since v2.3.3 you can register custom Oak privileges and grant them in your ACL configurations: 
 
 ```
 - privilege_config:


### PR DESCRIPTION
This is an exotic case, but it came from a real project. 
AC Tool can set custom privileges just fine, the only twist I had to do was to create them manually. Initially it was a script to run in AEM Fiddle. Something like :
```
<%@include file="/libs/foundation/global.jsp"%><%
%><%@page session="false" contentType="text/html; charset=utf-8" 
	pageEncoding="UTF-8"
    import="org.apache.sling.api.resource.*,
    java.util.*,
    javax.jcr.*,
    org.apache.jackrabbit.api.security.authorization.PrivilegeManager,
    org.apache.jackrabbit.api.*"%><pre><%

    String[] privileges = {"sling:feature1", "sling:feature2"};

    Session session = resourceResolver.adaptTo(Session.class);
    PrivilegeManager privilegeManager = ((JackrabbitWorkspace)session.getWorkspace()).getPrivilegeManager();
    for(String privilegeName : privileges){
      privilegeManager.registerPrivilege(privilegeName, false, new String[0]);
      out.println("created " + privilegeName);
    }

%></pre>
```

Ideally, custom privileges and ACEs should be all set in Yaml and installed in one go and this patch introduces support for this.

```
- privilege_config:

    - sling:feature:

    - sling:anotherFeature:
        - isAbstract: false
          declaredAggregateNames: jcr:read,jcr:write


- group_config:

    - sling-feature-users:
        - name:

- ace_config:

    - sling-feature-users:

        - path: /content
          permission: allow
          privileges: sling:feature

        - path: /content/dam
          permission: allow
          privileges: sling:anotherFeature
```
There is a new section `privilege_config` which is evaluated before installation of authorazibles. A privilege is defined by a (name, isAbstract, aggregateNames) tripplet and the impementation passes these arguments to Oak's PrivilegeManager#registerPrivilege
The built-in and created privileges live under /jcr:system/rep:privileges and you can check the created nodes in CRXDE.

Creating a privilege is a one-way operation. PrivilegeManager does not provide a "removePrivilege" operation, so from AC Tool prospective this cannot be purged. 

