### PR TITLE
fixes #428 removed sling:orderBefore from /apps/cq/core/content/nav/t…

### DIFF
--- a/accesscontroltool-apps-package/src/main/jcr_root/apps/cq/core/content/nav/tools/security/.content.xml
+++ b/accesscontroltool-apps-package/src/main/jcr_root/apps/cq/core/content/nav/tools/security/.content.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
-        jcr:primaryType="sling:OrderedFolder"
-        sling:orderBefore="deployment">
+        jcr:primaryType="sling:OrderedFolder">
 </jcr:root>


### PR DESCRIPTION
…ools/security so it won't hide other navigation bar items