### PR TITLE
accept oak packages exported with version 0

### DIFF
--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -293,7 +293,8 @@ Bundle-Name: ${project.name}
 Bundle-SymbolicName: biz.netcentric.cq.tools.accesscontroltool.bundle
 # export all versioned packages by default
 -exportcontents: ${packages;VERSIONED}
-Import-Package: org.apache.jackrabbit.oak.spi.security.authentication.external;resolution:=optional;version="[1.0,3)",org.apache.jackrabbit.oak.spi.security.authentication.external.basic;resolution:=optional,com.adobe.granite.crypto;resolution:=optional,com.adobe.granite.jmx.annotation;resolution:=optional,com.day.cq.security.util;resolution:=optional,*
+# broad version range for jackrabbit oak versions (as long as we need to support Oak < 1.7.12, see https://github.com/Netcentric/accesscontroltool/issues/435 and https://issues.apache.org/jira/browse/OAK-6945
+Import-Package: org.apache.jackrabbit.oak.spi.security.authentication.external;resolution:=optional;version="[0,2)",org.apache.jackrabbit.oak.spi.security.authentication.external.basic;resolution:=optional;version="[0,2)",org.apache.jackrabbit.oak.*;version="[0,2)",com.adobe.granite.crypto;resolution:=optional,com.adobe.granite.jmx.annotation;resolution:=optional,com.day.cq.security.util;resolution:=optional,*
                     ]]></bnd>
                 </configuration>
                 <executions>


### PR DESCRIPTION
some old Oak versions have not exported packages with a proper version:
https://issues.apache.org/jira/browse/OAK-3842
https://issues.apache.org/jira/browse/OAK-6945

This fixes #435