### PR TITLE
467: added check for null runmodes in case no config is provided and …

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/slingsettings/ExtendedSlingSettingsServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/slingsettings/ExtendedSlingSettingsServiceImpl.java
@@ -49,8 +49,12 @@ public class ExtendedSlingSettingsServiceImpl implements ExtendedSlingSettingsSe
         if(isCloudReady) {
             extendedRunmodes.add(ADDITIONAL_RUNMODE_CLOUD);
         }
-        List<String> additionalRunmodes = Arrays.asList(config.additionalRunmodes());
-        extendedRunmodes.addAll(additionalRunmodes);
+
+        if (config.additionalRunmodes() != null) {
+            List<String> additionalRunmodes = Arrays.asList(config.additionalRunmodes());
+            extendedRunmodes.addAll(additionalRunmodes);
+        }
+
         LOG.info("Default runmodes: {} Extended Runmodes: {}  isCloudReady: {}", defaultRunmodes, extendedRunmodes, isCloudReady);
     }
     


### PR DESCRIPTION
…no default runmode (dev/stage/prod) #467 