### PR TITLE
Upgrade snake yaml to latest version 1.27

### DIFF
--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.13</version>
+            <version>1.27</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.13</version>
+                <version>1.27</version>
                 <type>bundle</type>
             </dependency>
             <!-- due to https://bugs.openjdk.java.net/browse/JDK-8231581 OOTB JRE is not sufficient -->


### PR DESCRIPTION
Upgraded snake yaml to version 1.27 in pom to resolve security violation that opens up app to DOS type attacks.