### PR TITLE
fix EL upgrade

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluator.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluator.java
@@ -38,7 +38,7 @@ import org.apache.el.ExpressionFactoryImpl;
  * 
  * @author ghenzler */
 public class YamlMacroElEvaluator {
-    
+
     private ExpressionFactory expressionFactory;
     private ELContext context;
 
@@ -47,7 +47,7 @@ public class YamlMacroElEvaluator {
     public YamlMacroElEvaluator() {
 
         expressionFactory = new ExpressionFactoryImpl();
-
+        
         final VariableMapper variableMapper = new ElVariableMapper();
         final ElFunctionMapper functionMapper = new ElFunctionMapper();
         final CompositeELResolver compositeELResolver = new CompositeELResolver();
@@ -72,8 +72,26 @@ public class YamlMacroElEvaluator {
             public VariableMapper getVariableMapper() {
                 return variableMapper;
             }
-        };
 
+            @Override
+            public Object convertToType(Object obj, Class<?> type) {
+                if(obj == null) {
+                    return null;
+                }
+                if(type == null) {
+                    return obj;
+                }
+                if(type.equals(String.class)) {
+                    return String.valueOf(obj);
+                }
+                if(type.isAssignableFrom(obj.getClass())) {
+                    return obj;
+                } else {
+                    // no special conversions supported
+                    throw new IllegalStateException("Cannot convert "+obj.getClass() +" to " + type + " (object: "+obj+")");
+                }
+            }
+        };
     }
 
     public <T> T evaluateEl(String el, Class<T> expectedResultType, Map<? extends Object, ? extends Object> variables) {


### PR DESCRIPTION
the JUnit tests worked fine but with the EL upgrade 0be21f6ff1b2481b17b514e7bfc528e762f998dc in AEM the following exception is thrown:

```
avax.el.ELException: Unable to find ExpressionFactory of type [org.apache.el.ExpressionFactoryImpl]
	at javax.el.ExpressionFactory.newInstance(ExpressionFactory.java:149)
	at javax.el.ExpressionFactory.newInstance(ExpressionFactory.java:88)
	at javax.el.Util.getExpressionFactory(Util.java:130)
	at javax.el.ELManager.getExpressionFactory(ELManager.java:30)
	at javax.el.ELContext.convertToType(ELContext.java:325)
	at org.apache.el.ValueExpressionImpl.getValue(ValueExpressionImpl.java:192)
	at biz.netcentric.cq.tools.actool.configreader.YamlMacroElEvaluator.evaluateEl(YamlMacroElEvaluator.java:84)
	at biz.netcentric.cq.tools.actool.configreader.YamlMacroProcessorImpl.evaluateDefStatementOneLine(YamlMacroProcessorImpl.java:173)
	at biz.netcentric.cq.tools.actool.configreader.YamlMacroProcessorImpl.transform(YamlMacroProcessorImpl.java:109)
	at biz.netcentric.cq.tools.actool.configreader.YamlMacroProcessorImpl.transform(YamlMacroProcessorImpl.java:122)
	at biz.netcentric.cq.tools.actool.configreader.YamlMacroProcessorImpl.processMacros(YamlMacroProcessorImpl.java:64)
	at biz.netcentric.cq.tools.actool.configreader.YamlConfigurationMerger.getMergedConfigurations(YamlConfigurationMerger.java:118)
	at biz.netcentric.cq.tools.actool.impl.AcInstallationServiceImpl.installConfigurationFiles(AcInstallationServiceImpl.java:292)
	at biz.netcentric.cq.tools.actool.impl.AcInstallationServiceImpl.apply(AcInstallationServiceImpl.java:223)
	at biz.netcentric.cq.tools.actool.ui.AcToolUiService.doPost(AcToolUiService.java:78)
	at biz.netcentric.cq.tools.actool.ui.AcToolTouchUiServlet.doPost(AcToolTouchUiServlet.java:67)
	at org.apache.sling.api.servlets.SlingAllMethodsServlet.mayService(SlingAllMethodsServlet.java:146) [org.apache.sling.api:2.22.0]
	at org.apache.sling.api.servlets.SlingSafeMethodsServlet.service(SlingSafeMethodsServlet.java:342) [org.apache.sling.api:2.22.0]
	at org.apache.sling.api.servlets.SlingSafeMethodsServlet.service(SlingSafeMethodsServlet.java:374) [org.apache.sling.api:2.22.0]
	at org.apache.sling.engine.impl.request.RequestData.service(RequestData.java:552) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.SlingComponentFilterChain.render(SlingComponentFilterChain.java:44) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:82) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.WCMDebugFilter.doFilter(WCMDebugFilter.java:138) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.WCMComponentFilter.filterRootInclude(WCMComponentFilter.java:375) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at com.day.cq.wcm.core.impl.WCMComponentFilter.doFilter(WCMComponentFilter.java:190) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.page.PageLockFilter.doFilter(PageLockFilter.java:91) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.personalization.impl.TargetComponentFilter.doFilter(TargetComponentFilter.java:94) [com.day.cq.cq-personalization:5.13.20]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.SlingRequestProcessorImpl.processComponent(SlingRequestProcessorImpl.java:283) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.RequestSlingFilterChain.render(RequestSlingFilterChain.java:49) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:82) [org.apache.sling.engine:2.7.2]
	at com.day.cq.dam.core.impl.assetlinkshare.AdhocAssetShareAuthHandler.doFilter(AdhocAssetShareAuthHandler.java:447) [com.day.cq.dam.cq-dam-core:5.13.200]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.warp.TimeWarpFilter.doFilter(TimeWarpFilter.java:109) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at com.day.cq.dam.core.impl.servlet.ActivityRecordHandler.doFilter(ActivityRecordHandler.java:141) [com.day.cq.dam.cq-dam-core:5.13.200]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.rest.impl.servlet.ApiResourceFilter.doFilter(ApiResourceFilter.java:70) [com.adobe.granite.rest.api:1.1.16]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.requests.logging.impl.RequestLoggerImpl.doFilter(RequestLoggerImpl.java:122) [com.adobe.granite.requests.logging:1.0.22]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.rest.assets.impl.AssetContentDispositionFilter.doFilter(AssetContentDispositionFilter.java:96) [com.adobe.granite.rest.assets:1.0.58]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.AuthoringUIModeServiceImpl.doFilter(AuthoringUIModeServiceImpl.java:369) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.mobile.core.impl.redirect.RedirectFilter.doFilter(RedirectFilter.java:248) [com.day.cq.wcm.cq-wcm-mobile-core:5.11.10]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.debug.RequestProgressTrackerLogFilter.doFilter(RequestProgressTrackerLogFilter.java:110) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.dam.core.impl.servlet.DisableLegacyServletFilter.executeFilter(DisableLegacyServletFilter.java:197) [com.day.cq.dam.cq-dam-core:5.13.200]
	at com.day.cq.dam.core.impl.servlet.DisableLegacyServletFilter.doFilter(DisableLegacyServletFilter.java:154) [com.day.cq.dam.cq-dam-core:5.13.200]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.foundation.forms.FormsHandlingServletHelper.handleFilter(FormsHandlingServletHelper.java:226) [com.day.cq.wcm.cq-wcm-foundation:5.13.20]
	at com.day.cq.wcm.foundation.forms.impl.FormsHandlingServlet.doFilter(FormsHandlingServlet.java:138) [com.day.cq.wcm.cq-wcm-foundation:5.13.20]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.optout.impl.OptOutFilter.doFilter(OptOutFilter.java:76) [com.adobe.granite.optout:1.0.0]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.foundation.forms.FormsHandlingServletHelper.handleFilter(FormsHandlingServletHelper.java:226) [com.day.cq.wcm.cq-wcm-foundation:5.13.20]
	at com.adobe.cq.wcm.core.components.internal.servlets.CoreFormHandlingServlet.doFilter(CoreFormHandlingServlet.java:123) [com.adobe.cq.core.wcm.components.core:2.11.1]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.day.cq.wcm.core.impl.WCMRequestFilter.doFilter(WCMRequestFilter.java:90) [com.day.cq.wcm.cq-wcm-core:5.13.144]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.cq.history.impl.HistoryRequestFilter.doFilter(HistoryRequestFilter.java:122) [com.adobe.cq.cq-history:5.10.6]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.rewriter.impl.RewriterFilter.doFilter(RewriterFilter.java:87) [org.apache.sling.rewriter:1.2.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.httpcache.impl.InnerCacheFilter.doFilter(InnerCacheFilter.java:81) [com.adobe.granite.httpcache.core:1.0.8]
	at com.adobe.granite.httpcache.impl.InnerCacheFilter.doFilter(InnerCacheFilter.java:60) [com.adobe.granite.httpcache.core:1.0.8]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.i18n.impl.I18NFilter.doFilter(I18NFilter.java:131) [org.apache.sling.i18n:2.5.14]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.csrf.impl.CSRFFilter.doFilter(CSRFFilter.java:217) [com.adobe.granite.csrf:1.0.24]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.security.impl.ContentDispositionFilter.doFilter(ContentDispositionFilter.java:154) [org.apache.sling.security:1.1.20]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:78) [org.apache.sling.engine:2.7.2]
	at com.adobe.granite.resourceresolverhelper.impl.ResourceResolverHelperImpl.doFilter(ResourceResolverHelperImpl.java:83) [com.adobe.granite.resourceresolverhelper:1.0.4]
	at org.apache.sling.engine.impl.filter.AbstractSlingFilterChain.doFilter(AbstractSlingFilterChain.java:72) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.SlingRequestProcessorImpl.doProcessRequest(SlingRequestProcessorImpl.java:151) [org.apache.sling.engine:2.7.2]
	at org.apache.sling.engine.impl.SlingMainServlet.service(SlingMainServlet.java:250) [org.apache.sling.engine:2.7.2]
	at org.apache.felix.http.base.internal.handler.ServletHandler.handle(ServletHandler.java:123) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:86) [org.apache.felix.http.jetty:4.0.20]
	at com.adobe.acs.commons.wcm.impl.AemEnvironmentIndicatorFilter.doFilter(AemEnvironmentIndicatorFilter.java:179) [com.adobe.acs.acs-aem-commons-bundle:4.8.0]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at com.adobe.granite.cors.impl.CORSFilter.doFilter(CORSFilter.java:87) [com.adobe.granite.cors:1.0.14]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at com.adobe.granite.license.impl.LicenseCheckFilter.doFilter(LicenseCheckFilter.java:300) [com.adobe.granite.license:1.4.2]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.sling.i18n.impl.I18NFilter.doFilter(I18NFilter.java:131) [org.apache.sling.i18n:2.5.14]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.sling.featureflags.impl.FeatureManager.doFilter(FeatureManager.java:116) [org.apache.sling.featureflags:1.2.2]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.sling.engine.impl.log.RequestLoggerFilter.doFilter(RequestLoggerFilter.java:75) [org.apache.sling.engine:2.7.2]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.sling.engine.impl.parameters.RequestParameterSupportConfigurer.doFilter(RequestParameterSupportConfigurer.java:67) [org.apache.sling.engine:2.7.2]
	at org.apache.felix.http.base.internal.handler.FilterHandler.handle(FilterHandler.java:142) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.InvocationChain.doFilter(InvocationChain.java:81) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.Dispatcher$1.doFilter(Dispatcher.java:146) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager$2.doFilter(WhiteboardManager.java:1002) [org.apache.felix.http.jetty:4.0.20]
	at com.adobe.granite.cors.impl.CORSFilter.doFilter(CORSFilter.java:87) [com.adobe.granite.cors:1.0.14]
	at org.apache.felix.http.base.internal.handler.PreprocessorHandler.handle(PreprocessorHandler.java:136) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager$2.doFilter(WhiteboardManager.java:1008) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.sling.security.impl.ReferrerFilter.doFilter(ReferrerFilter.java:326) [org.apache.sling.security:1.1.20]
	at org.apache.felix.http.base.internal.handler.PreprocessorHandler.handle(PreprocessorHandler.java:136) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager$2.doFilter(WhiteboardManager.java:1008) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.sslfilter.internal.SslFilter.doFilter(SslFilter.java:97) [org.apache.felix.http.sslfilter:1.2.6]
	at org.apache.felix.http.base.internal.handler.PreprocessorHandler.handle(PreprocessorHandler.java:136) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager$2.doFilter(WhiteboardManager.java:1008) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.whiteboard.WhiteboardManager.invokePreprocessors(WhiteboardManager.java:1012) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.Dispatcher.dispatch(Dispatcher.java:91) [org.apache.felix.http.jetty:4.0.20]
	at org.apache.felix.http.base.internal.dispatch.DispatcherServlet.service(DispatcherServlet.java:49) [org.apache.felix.http.jetty:4.0.20]
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:725) [org.apache.felix.http.servlet-api:1.1.2]
	at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:763) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:551) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1610) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1369) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:489) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1580) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1284) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:191) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.Server.handle(Server.java:501) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:272) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:806) [org.apache.felix.http.jetty:4.0.20]
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:938) [org.apache.felix.http.jetty:4.0.20]
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.ClassNotFoundException: org.apache.el.ExpressionFactoryImpl
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:588)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at javax.el.ExpressionFactory.newInstance(ExpressionFactory.java:142)
	... 157 common frames omitted
```