### PR TITLE
Fix section identifier in documentation

### DIFF
--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -256,7 +256,7 @@ It is possible to define global variables (that are available across multiple ya
 
 ```
 - global_config:
-     vars:
+     - vars:
          - DEF groupPrefix="xyz"
          - DEF testArr=:
                   - val1


### PR DESCRIPTION
Current example throws an invalid section identifier exception.