### PR TITLE
#538 Fail for yaml lists with more than one item underneath authorizable config

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -217,18 +217,20 @@ public class YamlConfigReader implements ConfigReader {
             final List<Map<String, Object>> currentAuthorizableData = (List<Map<String, Object>>) currentMap.get(currentAuthorizableIdFromYaml);
 
             if ((currentAuthorizableData != null) && !currentAuthorizableData.isEmpty()) {
-
-                for (final Map<String, Object> currentPrincipalDataMap : currentAuthorizableData) {
-                    try {
-                        final AuthorizableConfigBean tmpPrincipalConfigBean = getNewAuthorizableConfigBean();
-                        setupAuthorizableBean(tmpPrincipalConfigBean, currentPrincipalDataMap, currentAuthorizableIdFromYaml, isGroupSection);
-                        if (authorizableValidator != null) {
-                            authorizableValidator.validate(tmpPrincipalConfigBean);
-                        }
-                        authorizableBeans.add(tmpPrincipalConfigBean);
-                    } catch (AcConfigBeanValidationException e) {
-                        throw new AcConfigBeanValidationException("Invalid authorizable " + currentAuthorizableIdFromYaml, e);
+                
+                if(currentAuthorizableData.size() > 1) {
+                    throw new AcConfigBeanValidationException("Invalid authorizable " + currentAuthorizableIdFromYaml +" - configuration needs to contain exactly one yaml list entry");
+                }
+                try {
+                    Map<String, Object> currentPrincipalDataMap = currentAuthorizableData.get(0);
+                    final AuthorizableConfigBean tmpPrincipalConfigBean = getNewAuthorizableConfigBean();
+                    setupAuthorizableBean(tmpPrincipalConfigBean, currentPrincipalDataMap, currentAuthorizableIdFromYaml, isGroupSection);
+                    if (authorizableValidator != null) {
+                        authorizableValidator.validate(tmpPrincipalConfigBean);
                     }
+                    authorizableBeans.add(tmpPrincipalConfigBean);
+                } catch (AcConfigBeanValidationException e) {
+                    throw new AcConfigBeanValidationException("Invalid authorizable " + currentAuthorizableIdFromYaml, e);
                 }
             }
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReader.java
@@ -217,9 +217,10 @@ public class YamlConfigReader implements ConfigReader {
             final List<Map<String, Object>> currentAuthorizableData = (List<Map<String, Object>>) currentMap.get(currentAuthorizableIdFromYaml);
 
             if ((currentAuthorizableData != null) && !currentAuthorizableData.isEmpty()) {
-                
-                if(currentAuthorizableData.size() > 1) {
-                    throw new AcConfigBeanValidationException("Invalid authorizable " + currentAuthorizableIdFromYaml +" - configuration needs to contain exactly one yaml list entry");
+
+                if (currentAuthorizableData.size() > 1) {
+                    throw new AcConfigBeanValidationException("Invalid authorizable " + currentAuthorizableIdFromYaml
+                            + " - configuration needs to contain exactly one yaml list entry");
                 }
                 try {
                     Map<String, Object> currentPrincipalDataMap = currentAuthorizableData.get(0);

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigurationMergerTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigurationMergerTest.java
@@ -88,6 +88,11 @@ public class YamlConfigurationMergerTest {
         getAcConfigurationForFile(getConfigurationMerger(), session, "test-invalid2.yaml");
     }
 
+    @Test(expected = AcConfigBeanValidationException.class)
+    public void testReadInvalidYaml3() throws IOException, RepositoryException, AcConfigBeanValidationException {
+        getAcConfigurationForFile(getConfigurationMerger(), session, "test-invalid3.yaml");
+    }
+    
     @Test()
     public void testReadEmptyYaml() throws IOException, RepositoryException, AcConfigBeanValidationException {
         getAcConfigurationForFile(getConfigurationMerger(), session, "test-empty.yaml");

--- a/accesscontroltool-bundle/src/test/resources/test-invalid3.yaml
+++ b/accesscontroltool-bundle/src/test/resources/test-invalid3.yaml
@@ -1,0 +1,8 @@
+
+- group_config:
+
+    - fragment-xyz-editor:
+        - path: /home/groups/test
+        # only one item allowed underneath group name 
+        - isMemberOf:
+            - fragment-xyz


### PR DESCRIPTION
Closes #538