### PR TITLE
#542 - refresh cache when using Prefetching UserManager

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
@@ -34,7 +34,7 @@ import biz.netcentric.cq.tools.actool.history.InstallationLogger;
  * <li>all groups, system users and anonymous (but not regular users)</li>
  * <li>all memberships between the preloaded authorizables</li>
  * <ul>
- * upon creation. 
+ * upon creation.
  * </p>
  * <p>
  * The membership relationships are cached in lookup maps to quickly be able to query the repository state for both
@@ -134,6 +134,12 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
         return authorizableCache.size();
     }
 
+    private void refreshAuthorizableCacheIfNeeded(final String id, final Authorizable authorizable) {
+        if (authorizableCache.containsKey(id)) {
+            authorizableCache.put(id, authorizable);
+        }
+    }
+
     // --- delegated methods
 
     public UserManager getOakUserManager() {
@@ -141,19 +147,26 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     }
 
     public User createUser(String userID, String password, Principal principal, String intermediatePath) throws RepositoryException {
-        return delegate.createUser(userID, password, principal, intermediatePath);
+        final User user = delegate.createUser(userID, password, principal, intermediatePath);
+        refreshAuthorizableCacheIfNeeded(userID, user);
+        return user;
     }
 
     public User createSystemUser(String userID, String intermediatePath) throws RepositoryException {
-        return delegate.createSystemUser(userID, intermediatePath);
+        final User user = delegate.createSystemUser(userID, intermediatePath);
+        refreshAuthorizableCacheIfNeeded(userID, user);
+        return user;
     }
 
     public Group createGroup(Principal principal) throws RepositoryException {
-        return delegate.createGroup(principal);
-    }
-    
-    public Group createGroup(Principal principal, String intermediatePath) throws RepositoryException {
-        return delegate.createGroup(principal, intermediatePath);
+        final Group group = delegate.createGroup(principal);
+        refreshAuthorizableCacheIfNeeded(principal.getName(), group);
+        return group;
     }
 
+    public Group createGroup(Principal principal, String intermediatePath) throws RepositoryException {
+        final Group group = delegate.createGroup(principal, intermediatePath);
+        refreshAuthorizableCacheIfNeeded(principal.getName(), group);
+        return group;
+    }
 }

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImplTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImplTest.java
@@ -131,7 +131,7 @@ public class AuthInstallerUserManagerPrefetchingImplTest {
 
         final PrincipalImpl group = new PrincipalImpl(GROUP_1);
         setupAuthorizable(groupCreated, GROUP_1, Collections.<Group> emptyList());
-        when(userManager.createGroup(eq(group))).thenReturn(groupCreated);
+        when(userManager.createGroup(group)).thenReturn(groupCreated);
 
         final Authorizable groupBeforeRecreation = prefetchingUserManager.getAuthorizable(GROUP_1);
         final Authorizable groupRecreated = prefetchingUserManager.createGroup(group);
@@ -148,7 +148,7 @@ public class AuthInstallerUserManagerPrefetchingImplTest {
 
         final PrincipalImpl group = new PrincipalImpl(GROUP_1);
         setupAuthorizable(groupCreated, GROUP_1, Collections.<Group> emptyList());
-        when(userManager.createGroup(eq(group), eq(GROUP1_PATH))).thenReturn(groupCreated);
+        when(userManager.createGroup(group, GROUP1_PATH)).thenReturn(groupCreated);
 
         final Authorizable groupBeforeRecreation = prefetchingUserManager.getAuthorizable(GROUP_1);
         final Authorizable groupRecreated = prefetchingUserManager.createGroup(group, GROUP1_PATH);


### PR DESCRIPTION
When a group/user is created, if the authorizable is present in the cache, it is updated.

I tested it using my project and there is no visible degradation on performance:

Executing `time <deploy command>`, results are:

**Code of this branch**
real    1m31.845s
real    1m32.099s
real    1m30.679s
real    1m31.160s

**2.7.1 execution**
real    1m31.349s
real    1m33.347s
real    1m30.282s
real    1m32.973s

closes #542 
