### PR TITLE
#562 - if the authorizable is removed, caches are cleared

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManager.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManager.java
@@ -22,6 +22,8 @@ interface AuthInstallerUserManager {
 
     UserManager getOakUserManager();
 
+    void removeAuthorizable(Authorizable authorizable) throws RepositoryException;
+
     // -- methods from oak UserManager that the AC tool uses (delegated, only the relevant methods are listed here)
 
     Authorizable getAuthorizable(String id) throws RepositoryException;

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthorizableInstallerServiceImpl.java
@@ -278,6 +278,7 @@ public class AuthorizableInstallerServiceImpl implements
             // initial set without regular users (those are never removed because that relationship is typically managed in AEM UI or LDAP/SAML/SSO/etc. )
             Set<String> relevantMembersInRepo = userManager.getDeclaredMembersWithoutRegularUsers(authorizableId);
 
+
             // ensure authorizables from config itself that are added via isMemberOf are not deleted
             relevantMembersInRepo = new HashSet<String>(CollectionUtils.subtract(relevantMembersInRepo, authorizablesFromConfigurations));
             
@@ -390,7 +391,7 @@ public class AuthorizableInstallerServiceImpl implements
             }
         }
 
-        groupForMigration.remove();
+        userManager.removeAuthorizable(groupForMigration);
         installLog.addMessage(LOG, "- Deleted group " + authorizableConfigBean.getMigrateFrom());
 
     }
@@ -451,7 +452,7 @@ public class AuthorizableInstallerServiceImpl implements
             }
 
             // delete existingAuthorizable;
-            existingAuthorizable.remove();
+            userManager.removeAuthorizable(existingAuthorizable);
 
             // create group again using values form config
             Authorizable newAuthorizable = createNewAuthorizable(acConfiguration, principalConfigBean, installLog, userManager, session);
@@ -621,7 +622,6 @@ public class AuthorizableInstallerServiceImpl implements
             Authorizable targetAuthorizable = userManager.getAuthorizable(groupId);
             ((Group) targetAuthorizable).addMember(currentAuthorizable);
         }
-
         for (String groupId : toBeRemovedMembers) {
             LOG.debug("Membership Change: Removing {} from members of group {} in repository", authorizableId, groupId);
             Authorizable targetAuthorizable = userManager.getAuthorizable(groupId);


### PR DESCRIPTION
When we remove an authorizable, if the cache is not refreshed, it will return outdated relations which cause the error seen.