### PR TITLE
Always use lower case for the the auth cache key to match Jackrabbits…

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
@@ -39,6 +39,10 @@ import biz.netcentric.cq.tools.actool.history.InstallationLogger;
  * upon creation.
  * </p>
  * <p>
+ * Authorizables as well as membership relationships are cached by their case-insensitive IDs in alignment
+ * with {@link org.apache.jackrabbit.oak.security.user.AuthorizableBaseProvider#getContentID(String authorizableId)}.
+ * </p>
+ * <p>
  * The membership relationships are cached in lookup maps to quickly be able to query the repository state for both
  * authorizable.declaredMemberOf() (this we call in this class also) and group.getDeclaredMembers(). Having called declaredMemberOf() for
  * all groups of the repository has also retrieved all memberships (expect regular user memberships), hence the method getDeclaredMembers()
@@ -54,8 +58,8 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     private final UserManager delegate;
     private final Map<String, Authorizable> authorizableCache = new CaseInsensitiveMap();
 
-    private final Map<String, Set<String>> nonRegularUserMembersByAuthorizableId = new HashMap<>();
-    private final Map<String, Set<String>> isMemberOfByAuthorizableId = new HashMap<>();
+    private final Map<String, Set<String>> nonRegularUserMembersByAuthorizableId = new CaseInsensitiveMap();
+    private final Map<String, Set<String>> isMemberOfByAuthorizableId = new CaseInsensitiveMap();
 
     public AuthInstallerUserManagerPrefetchingImpl(UserManager delegate, final ValueFactory valueFactory, InstallationLogger installLog)
             throws RepositoryException {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
@@ -73,7 +73,7 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
         while (authorizablesToPrefetchIt.hasNext()) {
             Authorizable auth = authorizablesToPrefetchIt.next();
             String authId = auth.getID();
-            authorizableCache.put(authId, auth);
+            authorizableCache.put(authId.toLowerCase(), auth);
 
             // init lists
             nonRegularUserMembersByAuthorizableId.put(authId, new HashSet<String>());
@@ -102,10 +102,10 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     }
 
     public Authorizable getAuthorizable(String id) throws RepositoryException {
-        Authorizable authorizable = authorizableCache.get(id);
+        Authorizable authorizable = authorizableCache.get(id.toLowerCase());
         if (authorizable == null) {
             authorizable = delegate.getAuthorizable(id);
-            authorizableCache.put(id, authorizable);
+            authorizableCache.put(id.toLowerCase(), authorizable);
         }
         return authorizable;
     }
@@ -136,8 +136,8 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     }
 
     private void refreshAuthorizableCacheIfNeeded(final String id, final Authorizable authorizable) {
-        if (authorizableCache.containsKey(id)) {
-            authorizableCache.put(id, authorizable);
+        if (authorizableCache.containsKey(id.toLowerCase())) {
+            authorizableCache.put(id.toLowerCase(), authorizable);
         }
     }
 
@@ -146,7 +146,7 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
         Objects.requireNonNull(authorizable);
 
         // remove auth from cache
-        authorizableCache.remove(authorizable.getID());
+        authorizableCache.remove(authorizable.getID().toLowerCase());
 
         // if auth is a group, remove auth from the cache which lists groups of a given user
         if (authorizable instanceof Group) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImpl.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import javax.jcr.RepositoryException;
 import javax.jcr.ValueFactory;
 
+import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
@@ -51,7 +52,7 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     private static final Logger LOG = LoggerFactory.getLogger(AuthInstallerUserManagerPrefetchingImpl.class);
 
     private final UserManager delegate;
-    private final Map<String, Authorizable> authorizableCache = new HashMap<>();
+    private final Map<String, Authorizable> authorizableCache = new CaseInsensitiveMap();
 
     private final Map<String, Set<String>> nonRegularUserMembersByAuthorizableId = new HashMap<>();
     private final Map<String, Set<String>> isMemberOfByAuthorizableId = new HashMap<>();
@@ -73,7 +74,7 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
         while (authorizablesToPrefetchIt.hasNext()) {
             Authorizable auth = authorizablesToPrefetchIt.next();
             String authId = auth.getID();
-            authorizableCache.put(authId.toLowerCase(), auth);
+            authorizableCache.put(authId, auth);
 
             // init lists
             nonRegularUserMembersByAuthorizableId.put(authId, new HashSet<String>());
@@ -102,10 +103,10 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     }
 
     public Authorizable getAuthorizable(String id) throws RepositoryException {
-        Authorizable authorizable = authorizableCache.get(id.toLowerCase());
+        Authorizable authorizable = authorizableCache.get(id);
         if (authorizable == null) {
             authorizable = delegate.getAuthorizable(id);
-            authorizableCache.put(id.toLowerCase(), authorizable);
+            authorizableCache.put(id, authorizable);
         }
         return authorizable;
     }
@@ -136,8 +137,8 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
     }
 
     private void refreshAuthorizableCacheIfNeeded(final String id, final Authorizable authorizable) {
-        if (authorizableCache.containsKey(id.toLowerCase())) {
-            authorizableCache.put(id.toLowerCase(), authorizable);
+        if (authorizableCache.containsKey(id)) {
+            authorizableCache.put(id, authorizable);
         }
     }
 
@@ -146,7 +147,7 @@ class AuthInstallerUserManagerPrefetchingImpl implements AuthInstallerUserManage
         Objects.requireNonNull(authorizable);
 
         // remove auth from cache
-        authorizableCache.remove(authorizable.getID().toLowerCase());
+        authorizableCache.remove(authorizable.getID());
 
         // if auth is a group, remove auth from the cache which lists groups of a given user
         if (authorizable instanceof Group) {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImplTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/authorizableinstaller/impl/AuthInstallerUserManagerPrefetchingImplTest.java
@@ -221,4 +221,13 @@ public class AuthInstallerUserManagerPrefetchingImplTest {
         assertNull(retrievedGroup3);
         assertFalse(groups.contains(group3.getID()));
     }
+
+    @Test
+    public void testCaseSensitiveAuthorizableCacheRetrieval() throws RepositoryException {
+        prefetchingUserManager = new AuthInstallerUserManagerPrefetchingImpl(userManager, valueFactory, installationLogger);
+        final Authorizable retrievedGroup3 = prefetchingUserManager.getAuthorizable(group1.getID());
+        final Authorizable retrievedGroup3Alternative = prefetchingUserManager.getAuthorizable(group1.getID().toUpperCase());
+
+        assertEquals(retrievedGroup3, retrievedGroup3Alternative);
+    }
 }


### PR DESCRIPTION
… default UserManagerImpl case-insensitive handling of authorizable id's, #575