### PR TITLE
Fixing CQRules:CQBP-84, that AEMaaCS consider as critical 

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AcHelper.java
@@ -64,22 +64,22 @@ public class AcHelper {
         return aceBean;
     }
 
-    public static AceBean getAceBean(final AceWrapper ace)
-            throws ValueFormatException, IllegalStateException,
-            RepositoryException {
+    public static AceBean getAceBean(final AceWrapper aceWrapper)
+            throws IllegalStateException, RepositoryException {
         final AceBean aceBean = new AceBean();
+        final JackrabbitAccessControlEntry ace = aceWrapper.getAce();
 
         aceBean.setPermission(ace.isAllow() ? "allow" : "deny");
-        aceBean.setJcrPath(ace.getJcrPath());
+        aceBean.setJcrPath(aceWrapper.getJcrPath());
         aceBean.setPrincipalName(ace.getPrincipal().getName());
-        aceBean.setPrivilegesString(ace.getPrivilegesString());
+        aceBean.setPrivilegesString(aceWrapper.getPrivilegesString());
 
         List<Restriction> restrictions = buildRestrictionsMap(ace);
         aceBean.setRestrictions(restrictions);
         return aceBean;
     }
 
-    private static List<Restriction> buildRestrictionsMap(final AceWrapper ace) throws RepositoryException, ValueFormatException {
+    private static List<Restriction> buildRestrictionsMap(final JackrabbitAccessControlEntry ace) throws RepositoryException {
         final String[] restrictionNames = ace.getRestrictionNames();
         final List<Restriction> restrictionsList = new ArrayList<Restriction>();
         for (final String restrictionName : restrictionNames) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceWrapper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/AceWrapper.java
@@ -8,11 +8,8 @@
  */
 package biz.netcentric.cq.tools.actool.helper;
 
-import java.security.Principal;
-
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
-import javax.jcr.ValueFormatException;
 import javax.jcr.security.Privilege;
 
 import org.apache.commons.lang3.StringUtils;
@@ -22,7 +19,7 @@ import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
  * from a system, in order to create an ACE Dump.
  *
  * @author jochenkoschorke */
-public class AceWrapper implements JackrabbitAccessControlEntry {
+public class AceWrapper {
     private final JackrabbitAccessControlEntry ace;
     private final String jcrPath;
 
@@ -34,6 +31,10 @@ public class AceWrapper implements JackrabbitAccessControlEntry {
 
     public String getJcrPath() {
         return this.jcrPath;
+    }
+
+    public JackrabbitAccessControlEntry getAce() {
+        return ace;
     }
 
     @Override
@@ -98,38 +99,6 @@ public class AceWrapper implements JackrabbitAccessControlEntry {
         }
         privilegesString = StringUtils.chop(privilegesString);
         return privilegesString;
-    }
-
-    @Override
-    public Principal getPrincipal() {
-        return this.ace.getPrincipal();
-    }
-
-    @Override
-    public Privilege[] getPrivileges() {
-        return this.ace.getPrivileges();
-    }
-
-    @Override
-    public boolean isAllow() {
-        return this.ace.isAllow();
-    }
-
-    @Override
-    public String[] getRestrictionNames() throws RepositoryException {
-        return this.ace.getRestrictionNames();
-    }
-
-    @Override
-    public Value getRestriction(String restrictionName)
-            throws ValueFormatException, RepositoryException {
-        return this.ace.getRestriction(restrictionName);
-    }
-
-    @Override
-    public Value[] getRestrictions(String restrictionName)
-            throws RepositoryException {
-        return this.ace.getRestrictions(restrictionName);
     }
 
 }


### PR DESCRIPTION
Fix for this issue: Netcentric/accesscontroltool#584

Bug text  'The product interface org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry annotated with @ProviderType should not be implemented by custom code'