### PR TITLE
Remove old oak index node used in versions prior 2.7.2

### DIFF
--- a/accesscontroltool-oakindex-package/src/main/META-INF/vault/filter.xml
+++ b/accesscontroltool-oakindex-package/src/main/META-INF/vault/filter.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-	<filter root="/oak:index/repACL-custom-1"/>
+    <filter root="/oak:index/repACL" type="cleanup"/><!-- legacy index node name, used prior version 2.7.2  -->
+    <filter root="/oak:index/repACL-custom-1"/>
 </workspaceFilter>


### PR DESCRIPTION
This closes #629