### PR TITLE
#648: switch to the regular toString for logging to prevent excessive memory usage

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AcConfiguration.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configmodel/AcConfiguration.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,5 +100,15 @@ public class AcConfiguration {
     public void setVirtualGroups(List<AuthorizableConfigBean> virtualGroups) {
         this.virtualGroups = virtualGroups;
     }
-    
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("globalConfiguration", globalConfiguration)
+                .append("authorizablesConfig", authorizablesConfig)
+                .append("aceBeansConfig", aceBeansConfig)
+                .append("obsoleteAuthorizables", obsoleteAuthorizables)
+                .append("virtualGroups", virtualGroups)
+                .toString();
+    }
 }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigurationMerger.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigurationMerger.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import org.apache.commons.lang3.time.StopWatch;
 import org.osgi.service.cm.ConfigurationPlugin;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -135,7 +134,7 @@ public class YamlConfigurationMerger implements ConfigurationMerger {
             yamlRootList = yamlMacroProcessor.processMacros(yamlRootList, globalVariables, installLog, session);
             // set merged config per file to ensure it is there in case of validation errors (for success, the actual merged config is set
             // after this loop)
-            installLog.setMergedAndProcessedConfig("# File " + sourceFile + "\n" + yamlParser.dump(yamlRootList));
+            installLog.setMergedAndProcessedConfig("# File " + sourceFile + "\n" + yamlRootList);
 
             final Set<String> sectionIdentifiers = new LinkedHashSet<String>();
 
@@ -225,7 +224,7 @@ public class YamlConfigurationMerger implements ConfigurationMerger {
         }
         
         installLog.setMergedAndProcessedConfig(
-                "# Merged configuration of " + configFileContentByFilename.size() + " files \n" + yamlParser.dump(acConfiguration));
+                "# Merged configuration of " + configFileContentByFilename.size() + " files \n" + acConfiguration);
 
         installLog.addMessage(LOG, "Loaded configuration in " + msHumanReadable(System.currentTimeMillis() - wholeConfigStart));
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/AcHistoryServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/AcHistoryServiceImpl.java
@@ -83,7 +83,7 @@ public class AcHistoryServiceImpl implements AcHistoryService {
 
             String mergedAndProcessedConfig = installLog.getMergedAndProcessedConfig();
             if (StringUtils.isNotBlank(mergedAndProcessedConfig)) {
-                JcrUtils.putFile(historyNode, "mergedConfig.yaml", "text/yaml",
+                JcrUtils.putFile(historyNode, "mergedConfig.txt", "text/plain",
                         new ByteArrayInputStream(mergedAndProcessedConfig.getBytes()));
             }
 


### PR DESCRIPTION
Replace serialization of config from Yaml to regular toString. 
## Comparison of memory usage:

### Before (OutOfMemory ons serialization)
<img width="413" alt="Size 685,768,736 B" src="https://user-images.githubusercontent.com/3098837/195309613-5372d052-be5d-4e08-bea0-785a74fa8b4c.png">

### After (no OutOfMemory)
<img width="507" alt="Size 1,572,864,032 B" src="https://user-images.githubusercontent.com/3098837/195309793-20b80ca6-503a-4fde-98e2-bc1b3fd56645.png">

## Example of serialized config in the history
<img width="1212" alt="image" src="https://user-images.githubusercontent.com/3098837/195311102-889c5cdd-2553-478b-aafa-123f40a977b2.png">

