### PR TITLE
Use dedicated profile "cloud" for building secondary cloud artifacts

### DIFF
--- a/accesscontroltool-content-package/pom.xml
+++ b/accesscontroltool-content-package/pom.xml
@@ -52,7 +52,6 @@
                 <groupId>com.day.jcr.vault</groupId>
                 <artifactId>content-package-maven-plugin</artifactId>
             </plugin>
-            
         </plugins>
     </build>
 </project>

--- a/accesscontroltool-oakindex-package/pom.xml
+++ b/accesscontroltool-oakindex-package/pom.xml
@@ -41,44 +41,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>cloud-generate-metadata</id>
-                        <goals>
-                            <goal>generate-metadata</goal>
-                        </goals>
-                        <configuration>
-                            <!-- application type for AEMaaCS,  -->
-                            <packageType>application</packageType>
-                            <classifier>cloud</classifier>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>cloud-package</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>cloud</classifier>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>cloud-validate-package</id>
-                        <goals>
-                            <goal>validate-package</goal>
-                        </goals>
-                        <configuration>
-                            <!-- workaround for https://issues.apache.org/jira/browse/JCRVLT-651  -->
-                            <packageFile>${project.build.directory}/${project.build.finalName}-cloud.zip</packageFile>
-                            <validatorsSettings>
-                                <jackrabbit-packagetype>
-                                    <options>
-                                        <!-- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/operations/indexing.html?lang=en#project-configuration -->
-                                        <immutableRootNodeNames>apps,libs,oak:index</immutableRootNodeNames>
-                                    </options>
-                                </jackrabbit-packagetype>
-                            </validatorsSettings>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>default-validate-package</id>
                         <goals>
                             <goal>validate-package</goal>
@@ -97,9 +59,6 @@
             <plugin>
                 <groupId>com.day.jcr.vault</groupId>
                 <artifactId>content-package-maven-plugin</artifactId>
-                <configuration>
-                    <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
-                </configuration>
             </plugin>
             
             <plugin>
@@ -163,4 +122,71 @@
 			</plugins>
 		</pluginManagement>
     </build>
+    <profiles>
+        <profile>
+            <id>cloud</id>
+            <!-- automatically active on CI -->
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- optionally generate two packages: one for cloud (classifier "cloud") and one for classic (no classifier) -->
+                        <groupId>org.apache.jackrabbit</groupId>
+                        <artifactId>filevault-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cloud-generate-metadata</id>
+                                <goals>
+                                    <goal>generate-metadata</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- application type for AEMaaCS,  -->
+                                    <packageType>application</packageType>
+                                    <classifier>cloud</classifier>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>cloud-package</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>cloud</classifier>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>cloud-validate-package</id>
+                                <goals>
+                                    <goal>validate-package</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>cloud</classifier>
+                                    <skipPackageFile>true</skipPackageFile>
+                                    <validatorsSettings>
+                                        <jackrabbit-packagetype>
+                                            <options>
+                                                <!-- https://experienceleague.adobe.com/docs/experience-manager-cloud-service/content/operations/indexing.html?lang=en#project-configuration -->
+                                                <immutableRootNodeNames>apps,libs,oak:index</immutableRootNodeNames>
+                                            </options>
+                                        </jackrabbit-packagetype>
+                                    </validatorsSettings>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.adobe.aem</groupId>
+                        <artifactId>aemanalyser-maven-plugin</artifactId>
+                        <configuration>
+                            <classifier>cloud</classifier>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/accesscontroltool-package/pom.xml
+++ b/accesscontroltool-package/pom.xml
@@ -55,7 +55,6 @@
             <artifactId>aem-sdk-api</artifactId>
             <version>2021.5.5343.20210524T070738Z-210527</version>
         </dependency>
-        
     </dependencies>
     <build>
         <pluginManagement>
@@ -77,30 +76,7 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <!-- for "cloud" package use repoinit instead of actool-content-package -->
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-cloud-package-resources</id>
-                        <!-- here the phase you need -->
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/vault-work-cloud/jcr_root</outputDirectory>
-                            <resources>
-                              <resource>
-                                <directory>src/main/jcr_root-cloud</directory>
-                                <filtering>false</filtering>
-                              </resource>
-                            </resources>
-                        </configuration> 
-                    </execution>
-                </executions>
-            </plugin>
-            <!-- generate two packages: one for cloud (classifier "cloud") and one for classic (no classifier) -->
+            <!-- optionally generate two packages: one for cloud (classifier "cloud") and one for classic (no classifier) -->
             <plugin>
                 <groupId>org.apache.jackrabbit</groupId>
                 <artifactId>filevault-package-maven-plugin</artifactId>
@@ -142,45 +118,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>cloud-generate-metadata</id>
-                        <goals>
-                            <goal>generate-metadata</goal>
-                        </goals>
-                        <configuration>
-                            <!-- everything via embed, no subpackages, no accesscontroltool-content-package -->
-                            <embeddeds>
-                                <embedded>
-                                    <artifactId>accesscontroltool-bundle</artifactId>
-                                </embedded>
-                                <embedded>
-                                    <artifactId>accesscontroltool-apps-package</artifactId>
-                                </embedded>
-                                <embedded>
-                                    <artifactId>accesscontroltool-startuphook-bundle</artifactId>
-                                    <target>/apps/netcentric/actool/install/27</target>
-                                </embedded>
-                            </embeddeds>
-                            <classifier>cloud</classifier>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>cloud-package</id>
-                        <goals>
-                            <goal>package</goal>
-                        </goals>
-                        <configuration>
-                            <classifier>cloud</classifier>
-                            <failOnDuplicateEntries>false</failOnDuplicateEntries>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-validate-package</id>
-                        <configuration>
-                            <!-- validate both generated packages in one execution -->
-                            <classifier>cloud</classifier>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>default-analyze-classes</id>
                         <phase>invalid</phase>
                     </execution>
@@ -193,10 +130,98 @@
             <plugin>
                 <groupId>com.adobe.aem</groupId>
                 <artifactId>aemanalyser-maven-plugin</artifactId>
-                <configuration>
-                    <classifier>cloud</classifier>
-                </configuration>
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>cloud</id>
+            <!-- automatically active on CI -->
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                     <!-- for "cloud" package use repoinit instead of actool-content-package -->
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-cloud-package-resources</id>
+                                <!-- here the phase you need -->
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/vault-work-cloud/jcr_root</outputDirectory>
+                                    <resources>
+                                      <resource>
+                                        <directory>src/main/jcr_root-cloud</directory>
+                                        <filtering>false</filtering>
+                                      </resource>
+                                    </resources>
+                                </configuration> 
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <!-- optionally generate two packages: one for cloud (classifier "cloud") and one for classic (no classifier) -->
+                        <groupId>org.apache.jackrabbit</groupId>
+                        <artifactId>filevault-package-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>cloud-generate-metadata</id>
+                                <goals>
+                                    <goal>generate-metadata</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- everything via embed, no subpackages, no accesscontroltool-content-package -->
+                                    <embeddeds>
+                                        <embedded>
+                                            <artifactId>accesscontroltool-bundle</artifactId>
+                                        </embedded>
+                                        <embedded>
+                                            <artifactId>accesscontroltool-apps-package</artifactId>
+                                        </embedded>
+                                        <embedded>
+                                            <artifactId>accesscontroltool-startuphook-bundle</artifactId>
+                                            <target>/apps/netcentric/actool/install/27</target>
+                                        </embedded>
+                                    </embeddeds>
+                                    <classifier>cloud</classifier>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>cloud-package</id>
+                                <goals>
+                                    <goal>package</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>cloud</classifier>
+                                    <failOnDuplicateEntries>false</failOnDuplicateEntries>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>default-validate-package</id>
+                                <configuration>
+                                    <!-- validate both generated packages in one execution -->
+                                    <classifier>cloud</classifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>com.adobe.aem</groupId>
+                        <artifactId>aemanalyser-maven-plugin</artifactId>
+                        <configuration>
+                            <classifier>cloud</classifier>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
         <maven.compiler.release>8</maven.compiler.release>
         <mockito.version>4.8.0</mockito.version>
         <junit.version>5.10.0</junit.version>
+        <!-- default content package file to install on AEM -->
+        <contentPackageFile>${project.build.directory}/${project.build.finalName}.zip</contentPackageFile>
     </properties>
 
     <modules>
@@ -301,7 +303,7 @@
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.3.0</version>
+                    <version>1.3.6</version>
                     <extensions>true</extensions>
                     <configuration>
                         <group>Netcentric</group>
@@ -389,6 +391,8 @@
                         <failOnError>true</failOnError>
                         <userId>${crx.username}</userId>
                         <password>${crx.password}</password>
+                        <!-- this should either point to the primary artifact file or a secondary one. There is no direct "classifier" support in this maven plugin -->
+                        <packageFile>${contentPackageFile}</packageFile>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -409,7 +413,7 @@
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.0-M6</version>
                     <configuration>
-                        <releaseProfiles>release</releaseProfiles>
+                        <releaseProfiles>release,cloud</releaseProfiles>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <!-- skip rebuilding the release with GitHub actions (https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/) -->
@@ -741,6 +745,20 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <!-- build packages for cloud (as secondary artifacts with classifier "cloud") and install those to AEM instead when leveraging content-package-maven-plugin -->
+            <id>cloud</id>
+            <!-- automatically active on CI -->
+            <activation>
+                <property>
+                    <name>env.CI</name>
+                </property>
+            </activation>
+            <properties>
+                <!-- install package with "cloud" classifier to AEM -->
+                <contentPackageFile>${project.build.directory}/${project.build.finalName}-cloud.zip</contentPackageFile>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
This profile is active by default for GH actions and release It also enables installation of the "cloud" content package to AEM