### PR TITLE
Properly encode JCR paths in XPath query

### DIFF
--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlConfigReaderTest.java
@@ -154,6 +154,12 @@ public class YamlConfigReaderTest {
                 () -> yamlConfigReader.getUserConfigurationBeans(yamlList, null));
     }
 
+    @Test
+    public void testCreateXPathQueryForPathWithWildcards() {
+        assertEquals("/jcr:root/var/test", YamlConfigReader.createXPathQueryForPathWithWildcards("/var/test"));
+        assertEquals("/jcr:root/var/*/_x0031_2node/*", YamlConfigReader.createXPathQueryForPathWithWildcards("/var/*/12node/*"));
+    }
+
     static List<Map> getYamlList(final String filename) throws IOException {
         final String configString = getTestConfigAsString(filename);
 


### PR DESCRIPTION
Keep wildcards unencoded, though
(https://issues.apache.org/jira/browse/JCR-5051)

This closes #688