### PR TITLE
Use option "updateIfAlreadyExists" to make sure description of existing

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/request/CreateGroupStep.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/request/CreateGroupStep.java
@@ -11,7 +11,7 @@ public class CreateGroupStep implements Step {
 
     // this cannot be a constant, but still needs to be serialized as literal
     @JsonProperty("option")
-    final String defaultOption = "ignoreIfAlreadyExists"; // the option "updateIfAlreadyExists" fails in case the group does already exist with a letter case, tracked in https://adminconsole.adobe.com/FA907D44536A3C2B0A490D4D@AdobeOrg/support/support-cases/E-001223901
+    final String defaultOption = "updateIfAlreadyExists";
     // unclear why name should be passed here as well: https://github.com/adobe-apiplatform/umapi-documentation/issues/87, doesn't seem necessary
     //@JsonProperty
     //String name; 


### PR DESCRIPTION
groups are properly updated

The previous option "ignoreIfAlreadyExists" was used as workaround for an UMAPI bug which was meanwhile fixed by Adobe.

This closes #721