### PR TITLE
Prevent empty "description" from being sent with UMAPI

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/request/CreateGroupStep.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/request/CreateGroupStep.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 @JsonTypeName("createUserGroup")
-@JsonInclude(Include.NON_NULL)
+@JsonInclude(Include.NON_EMPTY) // neither empty strings nor null values are allowed for "description", compare with https://github.com/Netcentric/accesscontroltool/issues/724
 public class CreateGroupStep implements Step {
 
     // this cannot be a constant, but still needs to be serialized as literal

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementIT.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementIT.java
@@ -52,6 +52,12 @@ class IMSUserManagementIT {
         AuthorizableConfigBean group2 = new AuthorizableConfigBean();
         group2.setAuthorizableId("testGroup");
         imsUserManagement.updateGroups(Collections.singleton(group2));
+        
+        // test with empty description
+        AuthorizableConfigBean group3 = new AuthorizableConfigBean();
+        group3.setAuthorizableId("testGroup");
+        group3.setDescription("");
+        imsUserManagement.updateGroups(Collections.singleton(group3));
     }
 
     private static String getMandatoryEnvironmentVariable(String name) {


### PR DESCRIPTION
This closes #724