### PR TITLE
Also switch to principal based service user mapping for non-Cloud

### DIFF
--- a/accesscontroltool-package/src/main/jcr_root-cloud/apps/netcentric/actool/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-ncActoolSystemUser.config
+++ b/accesscontroltool-package/src/main/jcr_root-cloud/apps/netcentric/actool/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-ncActoolSystemUser.config
@@ -1,1 +1,0 @@
-user.mapping=["biz.netcentric.cq.tools.accesscontroltool.bundle\=[actool-service]","biz.netcentric.cq.tools.accesscontroltool.startuphook.bundle\=[actool-service]"]

--- a/accesscontroltool-package/src/main/jcr_root/apps/netcentric/actool/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-ncActoolSystemUser.config
+++ b/accesscontroltool-package/src/main/jcr_root/apps/netcentric/actool/config/org.apache.sling.serviceusermapping.impl.ServiceUserMapperImpl.amended-ncActoolSystemUser.config
@@ -1,1 +1,1 @@
-user.mapping=["biz.netcentric.cq.tools.accesscontroltool.bundle\=actool-service","biz.netcentric.cq.tools.accesscontroltool.startuphook.bundle\=actool-service"]
+user.mapping=["biz.netcentric.cq.tools.accesscontroltool.bundle\=[actool-service]","biz.netcentric.cq.tools.accesscontroltool.startuphook.bundle\=[actool-service]"]


### PR DESCRIPTION
distribution

https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/security/best-practices-for-sling-service-user-mapping-and-service-user-definition

This closes #739