### PR TITLE
Support capturing groups for test users

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/TestUserConfigsCreator.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/TestUserConfigsCreator.java
@@ -1,4 +1,3 @@
-
 package biz.netcentric.cq.tools.actool.configreader;
 
 /*-
@@ -18,6 +17,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -71,10 +72,14 @@ public class TestUserConfigsCreator {
                 continue;
             }
             String groupId = groupAuthConfigBean.getAuthorizableId();
-            if (groupId.matches(autoCreateTestUsersConf.getCreateForGroupNamesRegEx())) {
+            Pattern pattern = Pattern.compile(autoCreateTestUsersConf.getCreateForGroupNamesRegEx());
+            Matcher matcher = pattern.matcher(groupId);
+            if (matcher.matches()) {
                 
                 Map<String, Object> vars = getVarsForAuthConfigBean(groupAuthConfigBean);
-                
+                // also add all captured groups from the matcher as variables
+                vars.putAll(getVarsForCapturedGroups(matcher));
+
                 AuthorizableConfigBean testUserConfigBean = new AuthorizableConfigBean();
                 testUserConfigBean.setIsGroup(false);
                 String testUserAuthId = autoCreateTestUsersConf.getPrefix() + groupId;
@@ -117,6 +122,14 @@ public class TestUserConfigsCreator {
                 "Created  " + testUserConfigBeansToAdd.size() + " test user configs at path " + autoCreateTestUsersConf.getPath()
                         + " (for groups matching " + autoCreateTestUsersConf.getCreateForGroupNamesRegEx() + ")");
 
+    }
+
+    Map<String, Object> getVarsForCapturedGroups(Matcher matcher) {
+        Map<String,Object> vars = new HashMap<>();
+        for (int i=0; i <= matcher.groupCount(); i++) {
+            vars.put("cg"+i, matcher.group(i));
+        }
+        return vars;
     }
 
     Map<String, Object> getVarsForAuthConfigBean(AuthorizableConfigBean groupAuthConfigBean) {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/TestUserConfigsCreatorTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/TestUserConfigsCreatorTest.java
@@ -13,8 +13,12 @@ package biz.netcentric.cq.tools.actool.configreader;
  * #L%
  */
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 
@@ -55,23 +59,38 @@ public class TestUserConfigsCreatorTest {
         assertEquals("testfolder/subfolder", testUserConfigsCreator.processValue("%{split(group.path,'/')[2]}/%{split(group.path,'/')[3]}", testVars));
         assertEquals("group-id", testUserConfigsCreator.processValue("%{substringAfter(group.id,'-')}", testVars));
     }
-    
+
+    @Test
+    public void testCapturingGroups() {
+        Matcher matcher = Pattern.compile("prefix-(.*)").matcher("prefix-group");
+        assertTrue(matcher.matches());
+        assertEquals("group", testUserConfigsCreator.processValue("%{cg1}", getTestVars(TEST_GROUP_NAME, matcher)));
+        assertEquals("prefix-group", testUserConfigsCreator.processValue("%{cg0}", getTestVars(TEST_GROUP_NAME, matcher)));
+    }
 
     @Test
     public void testMultipleReplacements() {
         assertEquals("Name "+TEST_GROUP_NAME+" Path "+TEST_GROUP_PATH, testUserConfigsCreator.processValue("Name %{group.name} Path %{group.path}", getTestVars()));
     }
 
-
     private Map<String, Object> getTestVars() {
         return getTestVars(TEST_GROUP_NAME);
     }
+
     private Map<String, Object> getTestVars(String name) {
+        Matcher matcher = Pattern.compile("").matcher("");
+        matcher.matches();
+        return getTestVars(name, matcher);
+    }
+
+    private Map<String, Object> getTestVars(String name, Matcher matcher) {
         AuthorizableConfigBean groupAuthConfigBean = new AuthorizableConfigBean();
         groupAuthConfigBean.setAuthorizableId(TEST_GROUP_ID);
         groupAuthConfigBean.setName(name);
         groupAuthConfigBean.setPath(TEST_GROUP_PATH);
-        return testUserConfigsCreator.getVarsForAuthConfigBean(groupAuthConfigBean);
+        Map<String, Object> vars = new HashMap<>(testUserConfigsCreator.getVarsForAuthConfigBean(groupAuthConfigBean));
+        vars.putAll(testUserConfigsCreator.getVarsForCapturedGroups(matcher));
+        return vars;
     }
 
 }

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -284,7 +284,7 @@ It is possible to automatically create test users (since v2.1.0) for groups give
 
 property | comment | required
 --- | --- | ---
-`createForGroupNamesRegEx` | A regex (matched against authorizableId of groups) to select the groups, test users should be created for | required
+`createForGroupNamesRegEx` | A regex (matched against authorizableId of groups) to select the groups, test users should be created for. The regular expression may contain [capturing groups](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg). | required
 `prefix` | The prefix for the authorizable id, for instance if prefix "tu-" is given, a user "tu-myproject-editors" will be created for group "myproject-editors" | required
 `name` | The name as configured in user's profile, allows for interpolation with EL *) | optional, defaults to "Test User %{group.name}"
 `description` | The description as configured in user's profile, allows for interpolation with EL *) | optional, not set by default
@@ -294,6 +294,8 @@ property | comment | required
 `skipForRunmodes` | The configuration is placed in a regular config file, hence it is possible to add one to an author configuration (located in e.g. in a folder "config.author" and one to a publish configuration (e.g. folder "config.publish"). To avoid creating special runmodes folders just for this configuration that list all runmodes except production, skipForRunmodes can be a comma-separated list of runmodes, where the users are not created.  Defaults to prod,production | optional
 
 *) Interpolation of group properties can be used with EL, however as `$` is evaluated at an earlier stage, `%{}` is used here. Available is `%{group.id}`, `%{group.name}`, `%{group.path}` or expressions like `%{split(group.path,'/')[2]}`.
+
+The special variables `%{cg<capturingGroupIndex>}` may be used to reference a capturing group from the regular expression given in `createForGroupNamesRegEx` matched against the group id. The variable `%{cg0}` stands for the complete group id (since version 3.2.0).
 
 Example:
 


### PR DESCRIPTION
Those may be referenced via "%{cg<groupIndex>}"

This closes #744