### PR TITLE
Limit number of group memberships to be managed with "add" step to 10

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagement.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagement.java
@@ -116,6 +116,7 @@ public class IMSUserManagement implements ExternalGroupManagement {
 
     public static final Logger LOG = LoggerFactory.getLogger(IMSUserManagement.class);
     private static final int MAX_NUM_COMMANDS_PER_REQUEST = 10;
+    private static final int MAX_NUM_GROUPS_PER_ADD_STEP = 10;
 
     private final Configuration config;
     private final CloseableHttpClient client;
@@ -218,15 +219,20 @@ public class IMSUserManagement implements ExternalGroupManagement {
         }
         // optionally make users group administrators
         if (config.groupAdmins() != null && config.groupAdmins().length > 0) {
-            Set<String> adminGroupNames = groupConfigs.stream()
+            // at most 10 groups per add command
+            AtomicInteger groupCounter = new AtomicInteger();
+            Collection<List<String>> adminGroupNameBatches = groupConfigs.stream()
                     .map(AuthorizableConfigBean::getAuthorizableId)
                     .map(id -> "_admin_" + id) // https://adobe-apiplatform.github.io/umapi-documentation/en/api/ActionsCmds.html#addRemoveAttr
-                    .collect(Collectors.toSet());
-            for (String groupAdmin : config.groupAdmins()) {
-                ActionCommand actionCommand = new UserActionCommand(groupAdmin);
-                AddGroupMembership addGroupMembership = new AddGroupMembership(adminGroupNames);
-                actionCommand.addStep(addGroupMembership);
-                actionCommands.add(actionCommand);
+                    .collect(Collectors.groupingBy
+                    (it->groupCounter.getAndIncrement() / MAX_NUM_GROUPS_PER_ADD_STEP)).values();
+            for (List<String> adminGroupNames : adminGroupNameBatches) {
+                for (String groupAdmin : config.groupAdmins()) {
+                    ActionCommand actionCommand = new UserActionCommand(groupAdmin);
+                    AddGroupMembership addGroupMembership = new AddGroupMembership(adminGroupNames);
+                    actionCommand.addStep(addGroupMembership);
+                    actionCommands.add(actionCommand);
+                }
             }
         }
         // update in batches of 10 commands

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementIT.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementIT.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -130,6 +132,26 @@ class IMSUserManagementIT {
         group.setAuthorizableId("testGroup");
         group.setDescription("my description");
         imsUserManagement.updateGroups(Collections.singleton(group));
+    }
+
+    @Test
+    void test25GroupsWithAdmin() throws IOException {
+        properties.put("groupAdmins", getMandatoryEnvironmentVariable("ACTOOL_IMS_IT_USERID"));
+        Configuration config = Converters.standardConverter().convert(properties).to(Configuration.class);
+        IMSUserManagement imsUserManagement = new IMSUserManagement(config, new HttpClientBuilderFactory() {
+            @Override
+            public HttpClientBuilder newBuilder() {
+                return HttpClientBuilder.create();
+            }
+        });
+        List<AuthorizableConfigBean> groups = new LinkedList<>();
+        for (int n=0; n<25; n++) {
+            AuthorizableConfigBean group = new AuthorizableConfigBean();
+            group.setAuthorizableId("testGroup" + n);
+            group.setDescription("my description" + n);
+            groups.add(group);
+        }
+        imsUserManagement.updateGroups(groups);
     }
 
     private static String getMandatoryEnvironmentVariable(String name) {


### PR DESCRIPTION
In fact the limit seems to be 20 but documented is 10, so better be conservative here.
Compare with
https://adobe-apiplatform.github.io/umapi-documentation/en/api/ActionsCmds.html

This closes #753