### PR TITLE
Rename RuntimeHelper methods to match their implementations closer

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aceinstaller/BaseAceBeanInstaller.java
@@ -111,8 +111,8 @@ public abstract class BaseAceBeanInstaller implements AceBeanInstaller {
 
     private Set<String> filterReadOnlyPaths(Set<String> paths, InstallationLogger history, Session session) {
 
-        boolean isCompositeNodeStore = RuntimeHelper.isCompositeNodeStore(session);
-        if (isCompositeNodeStore) {
+        boolean isAppsReadOnly = RuntimeHelper.isAppsReadOnly(session);
+        if (isAppsReadOnly) {
             Set<String> pathsToKeep = new TreeSet<String>();
             Set<String> readOnlyPaths = new TreeSet<String>();
             for (final String path : paths) {

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
@@ -45,8 +45,8 @@ public class RuntimeHelper {
             // see https://issues.apache.org/jira/browse/OAK-6563
             boolean hasCapability = session.hasCapability("addNode", appsNode, new Object[] { "nt:folder" });
             
-            boolean isCompositeNode = hasPermission && !hasCapability;
-            return isCompositeNode;
+            boolean isAppsReadOnly = hasPermission && !hasCapability;
+            return isAppsReadOnly;
         } catch(Exception e) {
             throw new IllegalStateException("Could not check if session is connected to a composite node store: "+e, e);
         }

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
@@ -30,7 +30,7 @@ public class RuntimeHelper {
 
     private static final String INSTALLER_CORE_BUNDLE_SYMBOLIC_ID = "org.apache.sling.installer.core";
 
-    public static boolean isCompositeNodeStore(Session session) {
+    public static boolean isAppsReadOnly(Session session) {
         
         try {
             String pathToCheck = "/apps";
@@ -60,7 +60,7 @@ public class RuntimeHelper {
         return bundleContext.getBundle(Constants.SYSTEM_BUNDLE_ID).adapt(FrameworkStartLevel.class).getStartLevel();
     }
     
-    public static boolean isCloudReadyInstance() {
+    public static boolean isCompositeNodeStore() {
         
         boolean isCloudReadyInstance = true;
         Bundle[] bundles = FrameworkUtil.getBundle(RuntimeHelper.class).getBundleContext().getBundles();

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelper.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class RuntimeHelper {
     public static final Logger LOG = LoggerFactory.getLogger(RuntimeHelper.class);
 
-    private static final String INSTALLER_CORE_BUNDLE_SYMBOLIC_ID = "org.apache.sling.installer.core";
+    public static final String INSTALLER_CORE_BUNDLE_SYMBOLIC_ID = "org.apache.sling.installer.core";
 
     public static boolean isAppsReadOnly(Session session) {
         

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/HistoryUtils.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/HistoryUtils.java
@@ -127,8 +127,8 @@ public class HistoryUtils {
                 trigger = "startup_hook_pckmgr)";
             } else {
                 // if the history is not yet copied to apps, it's the image build
-                boolean isImageBuild = RuntimeHelper.isCloudReadyInstance() && !session.itemExists(AC_HISTORY_PATH_IN_APPS);
-                if(isImageBuild) {
+                boolean isCompositeNodeStore = RuntimeHelper.isCompositeNodeStore() && !session.itemExists(AC_HISTORY_PATH_IN_APPS);
+                if(isCompositeNodeStore) {
                     trigger = "startup_hook_image_build";
                 } else {
                     trigger = "startup_hook";

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcConfigChangeTracker.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/impl/AcConfigChangeTracker.java
@@ -66,10 +66,10 @@ public class AcConfigChangeTracker {
     }
 
     private String createExecutionKey(Map<String, String> configFiles, String[] restrictedToPaths, Session session) {
-        boolean isCompositeNodeStore= RuntimeHelper.isCompositeNodeStore(session);
+        boolean isAppsReadOnly= RuntimeHelper.isAppsReadOnly(session);
         String restrictedToPathsKey = restrictedToPaths==null || restrictedToPaths.length==0 ? "ALL_PATHS" : StringUtils.join(restrictedToPaths, "+").replace("$", "").replace("^", "");
         String effectiveRootPathOfConfigs = getEffectiveConfigRootPath(configFiles);
-        String executionKey = "hash("+StringUtils.removeEnd(effectiveRootPathOfConfigs, "/").replace('/', '\\') + "," + restrictedToPathsKey.replace('/', '\\').replace(':', '_')+","+(isCompositeNodeStore?"compNodeStore":"stdRepo")+")";
+        String executionKey = "hash("+StringUtils.removeEnd(effectiveRootPathOfConfigs, "/").replace('/', '\\') + "," + restrictedToPathsKey.replace('/', '\\').replace(':', '_')+","+(isAppsReadOnly?"compNodeStore":"stdRepo")+")";
         return executionKey;
     }
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/installhook/AcToolInstallHook.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/installhook/AcToolInstallHook.java
@@ -72,7 +72,7 @@ public class AcToolInstallHook extends OsgiAwareInstallHook {
         }
         alreadyRan = true;
 
-        if (RuntimeHelper.isCloudReadyInstance()) {
+        if (RuntimeHelper.isCompositeNodeStore()) {
             log("InstallHook is skipped by default in cloud (use package property 'actool.forceInstallHookInCloud = true' to force run)",
                     listener);
             return;

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/slingsettings/ExtendedSlingSettingsServiceImpl.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/slingsettings/ExtendedSlingSettingsServiceImpl.java
@@ -80,8 +80,8 @@ public class ExtendedSlingSettingsServiceImpl implements ExtendedSlingSettingsSe
         Set<String> defaultRunmodes = slingSettingsService.getRunModes();
         extendedRunmodes = new HashSet<>();
         extendedRunmodes.addAll(defaultRunmodes);
-        boolean isCloudReady = RuntimeHelper.isCloudReadyInstance();
-        if(isCloudReady) {
+        boolean isCompositeNodeStore = RuntimeHelper.isCompositeNodeStore();
+        if(isCompositeNodeStore) {
             extendedRunmodes.add(ADDITIONAL_RUNMODE_CLOUD);
         }
 
@@ -90,7 +90,7 @@ public class ExtendedSlingSettingsServiceImpl implements ExtendedSlingSettingsSe
             extendedRunmodes.addAll(additionalRunmodes);
         }
 
-        LOG.info("Default runmodes: {} Extended Runmodes: {}  isCloudReady: {}", defaultRunmodes, extendedRunmodes, isCloudReady);
+        LOG.info("Default runmodes: {} Extended Runmodes: {}  isCompositeNodeStore: {}", defaultRunmodes, extendedRunmodes, isCompositeNodeStore);
     }
 
     @Override

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelperTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelperTest.java
@@ -13,15 +13,21 @@ package biz.netcentric.cq.tools.actool.helper.runtime;
  * #L%
  */
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,15 +36,44 @@ class RuntimeHelperTest {
     @Mock
     Session session;
 
+    @Mock
+    Bundle bundle;
+
+    @Mock
+    BundleContext bundleContext;
+
     @Test
     void shouldBeReadonlyIfRootWritable() throws RepositoryException {
         when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(true);
-        Assertions.assertTrue(RuntimeHelper.isAppsReadOnly(session));
+        assertTrue(RuntimeHelper.isAppsReadOnly(session));
     }
 
     @Test
     void shouldNotBeReadonlyIfRootNotWritable() throws RepositoryException {
         when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false);
-        Assertions.assertFalse(RuntimeHelper.isAppsReadOnly(session));
+        assertFalse(RuntimeHelper.isAppsReadOnly(session));
+    }
+
+    @Test
+    void shouldNotBeCompositeStoreWhenCoreInstallerPresent() {
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            setupOsgi(RuntimeHelper.INSTALLER_CORE_BUNDLE_SYMBOLIC_ID, mockedFrameworkUtil);
+            assertFalse(RuntimeHelper.isCompositeNodeStore());
+        }
+    }
+
+    @Test
+    void shouldBeCompositeStoreWhenCoreInstallerNotPresent() {
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            setupOsgi("unknown.bundle", mockedFrameworkUtil);
+            assertTrue(RuntimeHelper.isCompositeNodeStore());
+        }
+    }
+
+    private void setupOsgi(String t, MockedStatic<FrameworkUtil> mockedFrameworkUtil) {
+        when(bundle.getBundleContext()).thenReturn(bundleContext);
+        when(bundle.getSymbolicName()).thenReturn(t);
+        when(bundleContext.getBundles()).thenReturn(new Bundle[]{bundle});
+        mockedFrameworkUtil.when(() -> FrameworkUtil.getBundle(RuntimeHelper.class)).thenReturn(bundle);
     }
 }

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelperTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/helper/runtime/RuntimeHelperTest.java
@@ -1,0 +1,44 @@
+package biz.netcentric.cq.tools.actool.helper.runtime;
+
+/*-
+ * #%L
+ * Access Control Tool Bundle
+ * %%
+ * Copyright (C) 2015 - 2024 Cognizant Netcentric
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RuntimeHelperTest {
+
+    @Mock
+    Session session;
+
+    @Test
+    void shouldBeReadonlyIfRootWritable() throws RepositoryException {
+        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(true);
+        Assertions.assertTrue(RuntimeHelper.isAppsReadOnly(session));
+    }
+
+    @Test
+    void shouldNotBeReadonlyIfRootNotWritable() throws RepositoryException {
+        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false);
+        Assertions.assertFalse(RuntimeHelper.isAppsReadOnly(session));
+    }
+}

--- a/accesscontroltool-startuphook-bundle/pom.xml
+++ b/accesscontroltool-startuphook-bundle/pom.xml
@@ -61,6 +61,27 @@
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- START: Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- use the uber-jar always as last dependency because a lot of classes are provided also by other artifacts
             It is only used here as replacement for com.adobe.granite:com.adobe.granite.crypto:3.0.0 whose pom.xml is not publicly available -->
         <dependency>

--- a/accesscontroltool-startuphook-bundle/src/main/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImpl.java
+++ b/accesscontroltool-startuphook-bundle/src/main/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImpl.java
@@ -62,10 +62,10 @@ public class AcToolStartupHookServiceImpl {
     }
 
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
-    private AcInstallationService acInstallationService;
+    AcInstallationService acInstallationService;
 
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
-    private SlingRepository repository;
+    SlingRepository repository;
 
     private boolean isAppsReadOnly;
 
@@ -118,12 +118,7 @@ public class AcToolStartupHookServiceImpl {
     private void runAcToolAsync(final List<String> relevantPathsForInstallation, final int currentStartLevel, final boolean isCloudReady) {
 
         final AcToolStartupHookServiceImpl startupHook = this;
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                startupHook.runAcTool(relevantPathsForInstallation, currentStartLevel, isCloudReady);
-            }
-        }, THREAD_NAME_ASYNC).start();
+        new Thread(() -> startupHook.runAcTool(relevantPathsForInstallation, currentStartLevel, isCloudReady), THREAD_NAME_ASYNC).start();
     }
 
     private List<String> getRelevantPathsForInstallation() {

--- a/accesscontroltool-startuphook-bundle/src/main/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImpl.java
+++ b/accesscontroltool-startuphook-bundle/src/main/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImpl.java
@@ -67,23 +67,23 @@ public class AcToolStartupHookServiceImpl {
     @Reference(policyOption = ReferencePolicyOption.GREEDY)
     private SlingRepository repository;
 
-    private boolean isCompositeNodeStore;
+    private boolean isAppsReadOnly;
 
     @Activate
     public void activate(BundleContext bundleContext, Config config) {
 
-        boolean isCloudReady = RuntimeHelper.isCloudReadyInstance();
+        boolean isCompositeNodeStore = RuntimeHelper.isCompositeNodeStore();
         Config.StartupHookActivation activationMode = config.activationMode();
         boolean runAsyncForMutableConent = config.runAsyncForMutableConent();
         int currentStartLevel = RuntimeHelper.getCurrentStartLevel(bundleContext);
-        LOG.info("AcTool Startup Hook (start level: {}  isCloudReady: {}  activationMode: {}  runAsyncForMutableConent: {})",
+        LOG.info("AcTool Startup Hook (start level: {}  isCompositeNodeStore: {}  activationMode: {}  runAsyncForMutableConent: {})",
                 currentStartLevel,
-                isCloudReady,
+                isCompositeNodeStore,
                 activationMode,
                 runAsyncForMutableConent);
 
         boolean applyOnStartup = (activationMode == Config.StartupHookActivation.ALWAYS)
-                || (isCloudReady && activationMode == Config.StartupHookActivation.CLOUD_ONLY);
+                || (isCompositeNodeStore && activationMode == Config.StartupHookActivation.CLOUD_ONLY);
 
         if (applyOnStartup) {
 
@@ -91,16 +91,16 @@ public class AcToolStartupHookServiceImpl {
             LOG.info("Running AcTool with "
                     + (relevantPathsForInstallation.isEmpty() ? "all paths" : "paths " + relevantPathsForInstallation) + "...");
             
-            if (runAsyncForMutableConent && isCompositeNodeStore) {
+            if (runAsyncForMutableConent && isAppsReadOnly) {
                 LOG.info(
                         "Running AcTool asynchronously on mutable content of composite node store (config runAsyncForMutableConent=true)...");
-                runAcToolAsync(relevantPathsForInstallation, currentStartLevel, isCloudReady);
+                runAcToolAsync(relevantPathsForInstallation, currentStartLevel, isCompositeNodeStore);
             } else {
-                runAcTool(relevantPathsForInstallation, currentStartLevel, isCloudReady);
+                runAcTool(relevantPathsForInstallation, currentStartLevel, isCompositeNodeStore);
             }
 
         } else {
-            LOG.debug("Skipping AcTool Startup Hook: activationMode: {} isCloudReady: {}", activationMode, isCloudReady);
+            LOG.debug("Skipping AcTool Startup Hook: activationMode: {} isCompositeNodeStore: {}", activationMode, isCompositeNodeStore);
         }
 
     }
@@ -131,10 +131,10 @@ public class AcToolStartupHookServiceImpl {
         try {
             session = repository.loginService(null, null);
 
-            isCompositeNodeStore = RuntimeHelper.isCompositeNodeStore(session);
-            LOG.info("Repo is running with Composite NodeStore: {}", isCompositeNodeStore);
+            isAppsReadOnly = RuntimeHelper.isAppsReadOnly(session);
+            LOG.info("Repo is running with Composite NodeStore: {}", isAppsReadOnly);
             
-            if(!isCompositeNodeStore) {
+            if(!isAppsReadOnly) {
                 return Collections.emptyList();
             }
 
@@ -149,7 +149,7 @@ public class AcToolStartupHookServiceImpl {
                         AccessControlConstants.REP_REPO_POLICY).contains(node.getName())) {
                     continue;
                 }
-                if (isCompositeNodeStore && Arrays.asList("apps", "libs").contains(node.getName())) {
+                if (isAppsReadOnly && Arrays.asList("apps", "libs").contains(node.getName())) {
                     continue;
                 }
                 relevantPathsForInstallation.add(node.getPath());
@@ -179,7 +179,7 @@ public class AcToolStartupHookServiceImpl {
             try {
                 session = repository.loginService(null, null);
 
-                if(isCompositeNodeStore) {
+                if(isAppsReadOnly) {
                     LOG.info("Restoring history from /apps to /var");
 
                     if(session.nodeExists(HistoryUtils.AC_HISTORY_PATH_IN_APPS)) {

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -66,6 +66,25 @@ class AcToolStartupHookServiceImplTest {
     @Spy
     AcInstallationService installationService;
 
+    @ParameterizedTest
+    @CsvSource({
+            "false, false, true",
+            "false, true, false",
+            "true, false, true",
+            "true, true, false"
+    })
+    void testActivationSync(boolean runAsync, boolean canReadApps, boolean pathsForInstallationEmpty) throws RepositoryException, InterruptedException {
+        setup(canReadApps);
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            createAndActivateStartupHookService(mockedFrameworkUtil, runAsync);
+            // wait for the thread in AcToolStartupHookServiceImpl#runAcToolAsync to get started
+            if (runAsync && canReadApps) {
+                Thread.sleep(1000L);
+            }
+            verify(installationService, times(1)).apply(null,  pathsForInstallationEmpty ? new String[]{} : new String[]{ "^/$", "^$" }, true);
+        }
+    }
+
     void setup(boolean canReadApps) throws RepositoryException {
         FrameworkStartLevel startLevel = Mockito.mock(FrameworkStartLevel.class);
         when(startLevel.getStartLevel()).thenReturn(0);
@@ -86,27 +105,6 @@ class AcToolStartupHookServiceImplTest {
 
         when(bundleContext.getBundles()).thenReturn(new Bundle[] { bundle });
         when(bundleContext.getBundle(anyLong())).thenReturn(bundle);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "false, false, true",
-            "false, true, false",
-            "true, false, true"
-            // "true, true, false"
-            /*
-                last case is excluded, because it starts a thread in AcToolStartupHookServiceImpl#runAcToolAsync
-                so AcToolStartupHookServiceImpl#apply is invoked asynchronously and can not be checked easily in
-                unit test
-             */
-
-    })
-    void testActivationSync(boolean runAsync, boolean canReadApps, boolean pathsForInstallationEmpty) throws RepositoryException {
-        setup(canReadApps);
-        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
-            createAndActivateStartupHookService(mockedFrameworkUtil, runAsync);
-            verify(installationService, times(1)).apply(null,  pathsForInstallationEmpty ? new String[]{} : new String[]{ "^/$", "^$" }, true);
-        }
     }
 
     private void createAndActivateStartupHookService(MockedStatic<FrameworkUtil> mockedFrameworkUtil, boolean runAsyncForMutableContent) {

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -69,15 +69,29 @@ class AcToolStartupHookServiceImplTest {
         when(bundleContext.getBundles()).thenReturn(new Bundle[] { bundle });
         when(bundleContext.getBundle(anyLong())).thenReturn(bundle);
     }
+
     @Test
-    void testActivation() {
+    void testActivationSync() {
         try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
-            mockedFrameworkUtil.when(() -> FrameworkUtil.getBundle(RuntimeHelper.class)).thenReturn(bundle);
-            AcToolStartupHookServiceImpl startupHookService = new AcToolStartupHookServiceImpl();
-            startupHookService.repository = repository;
-            startupHookService.acInstallationService = installationService;
-            startupHookService.activate(bundleContext, config);
+            createAndActivateStartupHookService(mockedFrameworkUtil, false);
             verify(installationService, times(1)).apply(null,  new String[]{}, true);
         }
+    }
+
+    @Test
+    void testActivationAsync() {
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            createAndActivateStartupHookService(mockedFrameworkUtil, true);
+            verify(installationService, times(1)).apply(null,  new String[]{}, true);
+        }
+    }
+
+    private void createAndActivateStartupHookService(MockedStatic<FrameworkUtil> mockedFrameworkUtil, boolean runAsyncForMutableContent) {
+        mockedFrameworkUtil.when(() -> FrameworkUtil.getBundle(RuntimeHelper.class)).thenReturn(bundle);
+        AcToolStartupHookServiceImpl startupHookService = new AcToolStartupHookServiceImpl();
+        startupHookService.repository = repository;
+        startupHookService.acInstallationService = installationService;
+        when(config.runAsyncForMutableConent()).thenReturn(runAsyncForMutableContent);
+        startupHookService.activate(bundleContext, config);
     }
 }

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -16,11 +16,8 @@ package biz.netcentric.cq.tools.actool.startuphook.impl;
 import biz.netcentric.cq.tools.actool.api.AcInstallationService;
 import biz.netcentric.cq.tools.actool.helper.runtime.RuntimeHelper;
 import org.apache.sling.jcr.api.SlingRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -36,7 +33,6 @@ import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-import static org.apache.sling.api.resource.runtime.dto.AuthType.no;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,53 +62,81 @@ class AcToolStartupHookServiceImplTest {
     @Spy
     AcInstallationService installationService;
 
-    @ParameterizedTest
-    @CsvSource({
-            "false, false, true",
-            "false, true, false",
-            "true, false, true",
-            "true, true, false"
-    })
-    void testActivationSync(boolean runAsync, boolean canReadApps, boolean pathsForInstallationEmpty) throws RepositoryException, InterruptedException {
-        setup(canReadApps);
+    @Test
+    void testActivationWithModifiableRoot() throws RepositoryException {
+        boolean canSetPropertiesOnRootNode = true, runAsync = false, cloudOnly = false;
+        setup(canSetPropertiesOnRootNode, runAsync, cloudOnly);
         try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
-            createAndActivateStartupHookService(mockedFrameworkUtil, runAsync);
-            // wait for the thread in AcToolStartupHookServiceImpl#runAcToolAsync to get started
-            if (runAsync && canReadApps) {
-                Thread.sleep(1000L);
-            }
-            verify(installationService, times(1)).apply(null,  pathsForInstallationEmpty ? new String[]{} : new String[]{ "^/$", "^$" }, true);
+            createAndActivateStartupHookService(mockedFrameworkUtil);
+            verify(installationService, times(1)).apply(null, new String[]{"^/$", "^$"}, true);
         }
     }
 
-    void setup(boolean canReadApps) throws RepositoryException {
+    @Test
+    void testActivationWithUnmodifiableRoot() throws RepositoryException {
+        boolean canSetPropertiesOnRootNode = false, runAsync = false, cloudOnly = false;
+        setup(canSetPropertiesOnRootNode, runAsync, cloudOnly);
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            createAndActivateStartupHookService(mockedFrameworkUtil);
+            verify(installationService, times(1)).apply(null, new String[]{}, true);
+        }
+    }
+
+    @Test
+    void testActivationWithCloudOnly() throws RepositoryException {
+        boolean canSetPropertiesOnRootNode = false, runAsync = false, cloudOnly = true;
+        setup(canSetPropertiesOnRootNode, runAsync, cloudOnly);
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            createAndActivateStartupHookService(mockedFrameworkUtil);
+            verify(installationService, never()).apply(null, new String[]{"^/$", "^$"}, true);
+        }
+    }
+
+    @Test
+    void testActivationWithAsync() throws RepositoryException, InterruptedException {
+        boolean canSetPropertiesOnRootNode = true, runAsync = true, cloudOnly = false;
+        setup(canSetPropertiesOnRootNode, runAsync, cloudOnly);
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            createAndActivateStartupHookService(mockedFrameworkUtil);
+            Thread.sleep(1000L);
+            verify(installationService, times(1)).apply(null, new String[]{"^/$", "^$"}, true);
+        }
+    }
+
+    void setup(boolean canSetPropertiesOnRootNode, boolean runAsyncForMutableContent, boolean cloudOnly) throws RepositoryException {
         FrameworkStartLevel startLevel = Mockito.mock(FrameworkStartLevel.class);
         when(startLevel.getStartLevel()).thenReturn(0);
 
-        when(config.activationMode()).thenReturn(AcToolStartupHookServiceImpl.Config.StartupHookActivation.ALWAYS);
-
-        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(canReadApps);
-        if (canReadApps) {
+        if (canSetPropertiesOnRootNode) {
+            when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(true);
             when(noChildren.hasNext()).thenReturn(false);
             when(rootNode.getNodes()).thenReturn(noChildren);
             when(session.getRootNode()).thenReturn(rootNode);
+        } else if (!canSetPropertiesOnRootNode && !cloudOnly){
+            when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false);
         }
-        when(repository.loginService(null, null)).thenReturn(session);
+        if (!cloudOnly) {
+            when(repository.loginService(null, null)).thenReturn(session);
+        }
 
         when(bundle.getBundleContext()).thenReturn(bundleContext);
         when(bundle.getSymbolicName()).thenReturn(RuntimeHelper.INSTALLER_CORE_BUNDLE_SYMBOLIC_ID);
         when(bundle.adapt(FrameworkStartLevel.class)).thenReturn(startLevel);
 
-        when(bundleContext.getBundles()).thenReturn(new Bundle[] { bundle });
+        when(bundleContext.getBundles()).thenReturn(new Bundle[]{bundle});
         when(bundleContext.getBundle(anyLong())).thenReturn(bundle);
+
+        when(config.runAsyncForMutableConent()).thenReturn(runAsyncForMutableContent);
+        when(config.activationMode()).thenReturn(cloudOnly ?
+                AcToolStartupHookServiceImpl.Config.StartupHookActivation.CLOUD_ONLY :
+                AcToolStartupHookServiceImpl.Config.StartupHookActivation.ALWAYS);
     }
 
-    private void createAndActivateStartupHookService(MockedStatic<FrameworkUtil> mockedFrameworkUtil, boolean runAsyncForMutableContent) {
+    private void createAndActivateStartupHookService(MockedStatic<FrameworkUtil> mockedFrameworkUtil) {
         mockedFrameworkUtil.when(() -> FrameworkUtil.getBundle(RuntimeHelper.class)).thenReturn(bundle);
         AcToolStartupHookServiceImpl startupHookService = new AcToolStartupHookServiceImpl();
         startupHookService.repository = repository;
         startupHookService.acInstallationService = installationService;
-        when(config.runAsyncForMutableConent()).thenReturn(runAsyncForMutableContent);
         startupHookService.activate(bundleContext, config);
     }
 }

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -19,6 +19,8 @@ import org.apache.sling.jcr.api.SlingRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -29,9 +31,12 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
 
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
+import static org.apache.sling.api.resource.runtime.dto.AuthType.no;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -47,19 +52,32 @@ class AcToolStartupHookServiceImplTest {
     AcToolStartupHookServiceImpl.Config config;
 
     @Mock
+    Session session;
+
+    @Mock
     SlingRepository repository;
+
+    @Mock
+    Node rootNode;
+
+    @Mock
+    NodeIterator noChildren;
 
     @Spy
     AcInstallationService installationService;
 
-    @BeforeEach
-    void setup() throws RepositoryException {
+    void setup(boolean canReadApps) throws RepositoryException {
         FrameworkStartLevel startLevel = Mockito.mock(FrameworkStartLevel.class);
         when(startLevel.getStartLevel()).thenReturn(0);
 
         when(config.activationMode()).thenReturn(AcToolStartupHookServiceImpl.Config.StartupHookActivation.ALWAYS);
 
-        Session session = mock(Session.class);
+        when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(canReadApps);
+        if (canReadApps) {
+            when(noChildren.hasNext()).thenReturn(false);
+            when(rootNode.getNodes()).thenReturn(noChildren);
+            when(session.getRootNode()).thenReturn(rootNode);
+        }
         when(repository.loginService(null, null)).thenReturn(session);
 
         when(bundle.getBundleContext()).thenReturn(bundleContext);
@@ -70,19 +88,24 @@ class AcToolStartupHookServiceImplTest {
         when(bundleContext.getBundle(anyLong())).thenReturn(bundle);
     }
 
-    @Test
-    void testActivationSync() {
-        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
-            createAndActivateStartupHookService(mockedFrameworkUtil, false);
-            verify(installationService, times(1)).apply(null,  new String[]{}, true);
-        }
-    }
+    @ParameterizedTest
+    @CsvSource({
+            "false, false, true",
+            "false, true, false",
+            "true, false, true"
+            // "true, true, false"
+            /*
+                last case is excluded, because it starts a thread in AcToolStartupHookServiceImpl#runAcToolAsync
+                so AcToolStartupHookServiceImpl#apply is invoked asynchronously and can not be checked easily in
+                unit test
+             */
 
-    @Test
-    void testActivationAsync() {
+    })
+    void testActivationSync(boolean runAsync, boolean canReadApps, boolean pathsForInstallationEmpty) throws RepositoryException {
+        setup(canReadApps);
         try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
-            createAndActivateStartupHookService(mockedFrameworkUtil, true);
-            verify(installationService, times(1)).apply(null,  new String[]{}, true);
+            createAndActivateStartupHookService(mockedFrameworkUtil, runAsync);
+            verify(installationService, times(1)).apply(null,  pathsForInstallationEmpty ? new String[]{} : new String[]{ "^/$", "^$" }, true);
         }
     }
 

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -98,6 +98,7 @@ class AcToolStartupHookServiceImplTest {
         setup(canSetPropertiesOnRootNode, runAsync, cloudOnly);
         try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
             createAndActivateStartupHookService(mockedFrameworkUtil);
+            // best attempt to test asynchronous invocation in AcToolStartupHookServiceImpl#runAcToolAsync
             Thread.sleep(1000L);
             verify(installationService, times(1)).apply(null, new String[]{"^/$", "^$"}, true);
         }
@@ -112,7 +113,7 @@ class AcToolStartupHookServiceImplTest {
             when(noChildren.hasNext()).thenReturn(false);
             when(rootNode.getNodes()).thenReturn(noChildren);
             when(session.getRootNode()).thenReturn(rootNode);
-        } else if (!canSetPropertiesOnRootNode && !cloudOnly) {
+        } else if (!cloudOnly) {
             when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false);
         }
         if (!cloudOnly) {

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -1,0 +1,83 @@
+package biz.netcentric.cq.tools.actool.startuphook.impl;
+
+/*-
+ * #%L
+ * Access Control Tool Bundle
+ * %%
+ * Copyright (C) 2015 - 2024 Cognizant Netcentric
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+
+import biz.netcentric.cq.tools.actool.api.AcInstallationService;
+import biz.netcentric.cq.tools.actool.helper.runtime.RuntimeHelper;
+import org.apache.sling.jcr.api.SlingRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.startlevel.FrameworkStartLevel;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AcToolStartupHookServiceImplTest {
+
+    @Mock
+    Bundle bundle;
+
+    @Mock
+    BundleContext bundleContext;
+
+    @Mock
+    AcToolStartupHookServiceImpl.Config config;
+
+    @Mock
+    SlingRepository repository;
+
+    @Spy
+    AcInstallationService installationService;
+
+    @BeforeEach
+    void setup() throws RepositoryException {
+        FrameworkStartLevel startLevel = Mockito.mock(FrameworkStartLevel.class);
+        when(startLevel.getStartLevel()).thenReturn(0);
+
+        when(config.activationMode()).thenReturn(AcToolStartupHookServiceImpl.Config.StartupHookActivation.ALWAYS);
+
+        Session session = mock(Session.class);
+        when(repository.loginService(null, null)).thenReturn(session);
+
+        when(bundle.getBundleContext()).thenReturn(bundleContext);
+        when(bundle.getSymbolicName()).thenReturn(RuntimeHelper.INSTALLER_CORE_BUNDLE_SYMBOLIC_ID);
+        when(bundle.adapt(FrameworkStartLevel.class)).thenReturn(startLevel);
+
+        when(bundleContext.getBundles()).thenReturn(new Bundle[] { bundle });
+        when(bundleContext.getBundle(anyLong())).thenReturn(bundle);
+    }
+    @Test
+    void testActivation() {
+        try (MockedStatic<FrameworkUtil> mockedFrameworkUtil = mockStatic(FrameworkUtil.class)) {
+            mockedFrameworkUtil.when(() -> FrameworkUtil.getBundle(RuntimeHelper.class)).thenReturn(bundle);
+            AcToolStartupHookServiceImpl startupHookService = new AcToolStartupHookServiceImpl();
+            startupHookService.repository = repository;
+            startupHookService.acInstallationService = installationService;
+            startupHookService.activate(bundleContext, config);
+            verify(installationService, times(1)).apply(null,  new String[]{}, true);
+        }
+    }
+}

--- a/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
+++ b/accesscontroltool-startuphook-bundle/src/test/java/biz/netcentric/cq/tools/actool/startuphook/impl/AcToolStartupHookServiceImplTest.java
@@ -112,7 +112,7 @@ class AcToolStartupHookServiceImplTest {
             when(noChildren.hasNext()).thenReturn(false);
             when(rootNode.getNodes()).thenReturn(noChildren);
             when(session.getRootNode()).thenReturn(rootNode);
-        } else if (!canSetPropertiesOnRootNode && !cloudOnly){
+        } else if (!canSetPropertiesOnRootNode && !cloudOnly) {
             when(session.hasPermission("/", Session.ACTION_SET_PROPERTY)).thenReturn(false);
         }
         if (!cloudOnly) {

--- a/accesscontroltool-startuphook-bundle/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/accesscontroltool-startuphook-bundle/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <bouncycastle.version>1.64</bouncycastle.version>
         <!-- release sets API classpath, source and target, see  https://docs.oracle.com/javase/9/tools/javac.htm#GUID-AEEC9F07-CB49-4E96-8BC7-BCC2C7F725C9__GUID-D343F6B4-3FDD-43A8-AD24-43DD70214471  and http://openjdk.java.net/jeps/247 -->
         <maven.compiler.release>8</maven.compiler.release>
-        <mockito.version>4.8.0</mockito.version>
+        <mockito.version>5.13.0</mockito.version>
         <junit.version>5.10.0</junit.version>
         <!-- default content package file to install on AEM -->
         <contentPackageFile>${project.build.directory}/${project.build.finalName}.zip</contentPackageFile>


### PR DESCRIPTION
Solves https://github.com/Netcentric/accesscontroltool/issues/743 