### PR TITLE
Prevent ISE: Duplicate key when calling getGroups

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagement.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagement.java
@@ -334,12 +334,20 @@ public class IMSUserManagement implements ExternalGroupManagement {
         while (!isLastPage) {
             GroupResponse response = getGroups(token, page++);
             isLastPage = response.isLastPage;
-            groups.putAll(response.groups.stream().collect(Collectors.toMap(g -> g.getGroupName().toLowerCase(Locale.ROOT), Function.identity())));
+            groups.putAll(response.groups.stream()
+                    .filter(g -> "USER_GROUP".equals(g.type))
+                    .collect(Collectors.toMap(
+                            g -> g.getGroupName().toLowerCase(Locale.ROOT), 
+                            Function.identity(),
+                            (a,b) -> {
+                                LOG.warn("Duplicate group name {} found, keeping first occurrence", a.getGroupName());
+                                return a;
+                            })));
         }
         return groups;
     }
 
-    private GroupResponse getGroups(String token, int page) throws IOException {
+    GroupResponse getGroups(String token, int page) throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         HttpGet httpGet;
         try {

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/ims/IMSUserManagementTest.java
@@ -1,0 +1,76 @@
+package biz.netcentric.cq.tools.actool.ims;
+
+/*-
+ * #%L
+ * Access Control Tool Bundle
+ * %%
+ * Copyright (C) 2015 - 2024 Cognizant Netcentric
+ * %%
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * #L%
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.osgi.services.HttpClientBuilderFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import biz.netcentric.cq.tools.actool.ims.IMSUserManagement.Configuration;
+import biz.netcentric.cq.tools.actool.ims.response.GroupResponse;
+import biz.netcentric.cq.tools.actool.ims.response.IMSGroup;
+
+@ExtendWith(MockitoExtension.class)
+class IMSUserManagementTest {
+
+    private static final String MOCK_TOKEN = "mockToken";
+    @Mock
+    private Configuration configuration;
+    @Mock
+    private HttpClientBuilderFactory httpClientBuilderFactory;
+    @Mock
+    private HttpClientBuilder httpClientBuilder;
+
+    @BeforeEach
+    void setUp() {
+        Mockito.when(httpClientBuilderFactory.newBuilder()).thenReturn(httpClientBuilder);
+    }
+
+    @Test
+    void testGetGroups() throws IOException {
+        IMSUserManagement imsUserManagement = new IMSUserManagement(configuration, httpClientBuilderFactory) {
+            @Override
+            GroupResponse getGroups(String token, int page) throws java.io.IOException {
+                try (InputStream inputStream = getClass().getResourceAsStream("groupResponse" + page +".json")) {
+                    Objects.requireNonNull(inputStream, "Resource not found: groupResponse" + page + ".json");
+                    ObjectMapper objectMapper = new ObjectMapper();
+                    return objectMapper.readValue(inputStream, GroupResponse.class);
+                }
+            }
+        };
+        Map<String, IMSGroup> groups = imsUserManagement.getGroups(MOCK_TOKEN);
+        assertEquals(2, groups.size());
+        // check keys only
+        Set<String> expectedKeys = new HashSet<>(Arrays.asList("document cloud 1", "document cloud 2"));
+        assertEquals(expectedKeys, groups.keySet());
+    }
+
+}

--- a/accesscontroltool-bundle/src/test/resources/biz/netcentric/cq/tools/actool/ims/groupResponse0.json
+++ b/accesscontroltool-bundle/src/test/resources/biz/netcentric/cq/tools/actool/ims/groupResponse0.json
@@ -1,0 +1,64 @@
+{
+  "lastPage": true,
+  "result": "success",
+  "groups": [
+        {
+          "type": "SYSADMIN_GROUP",
+          "groupName": "Administrators",
+          "memberCount": 11
+        },
+        {
+          "type": "USER_GROUP",
+          "groupName": "Document Cloud 1",
+          "memberCount": 26,
+          "adminGroupName": "_admin_Document Cloud 1",
+          "licenseQuota": "2"
+        },
+        {
+          "type": "USER_GROUP",
+          "groupName": "Document Cloud 2",
+          "memberCount": 26,
+          "adminGroupName": "_admin_Document Cloud 1",
+          "licenseQuota": "2"
+        },
+        {
+          "type": "PRODUCT_PROFILE",
+          "groupName": "Default Support Profile",
+          "memberCount": 0,
+          "productName": "All Apps plan - 100 GB",
+          "licenseQuota": "8"
+        },
+        {
+          "type": "PRODUCT_ADMIN_GROUP",
+          "groupName": "_product_admin_Adobe Document Cloud for business",
+          "memberCount": 2,
+          "productProfileName": "Adobe Document Cloud for business"
+        },
+        {
+          "type": "PRODUCT_ADMIN_GROUP",
+          "groupName": "_product_admin_Adobe Document Cloud for business",
+          "memberCount": 2,
+          "productProfileName": "Adobe Document Cloud for business"
+        },
+        {
+            "groupId": 561043099,
+            "groupName": "_product_admin_Adobe Experience Manager as a Cloud Service (ENTERPRISE_PRODUCT,Cloud Manager,DX - E123)",
+            "type": "PRODUCT_ADMIN_GROUP",
+            "memberCount": 7,
+            "productName": "Adobe Experience Manager as a Cloud Service (ENTERPRISE_PRODUCT,Cloud Manager,DX - E123)"
+        },
+        {
+            "groupId": 743706203,
+            "groupName": "_product_admin_Adobe Experience Manager as a Cloud Service (ENTERPRISE_PRODUCT,Cloud Manager,DX - E123)",
+            "type": "PRODUCT_ADMIN_GROUP",
+            "memberCount": 1,
+            "productName": "Adobe Experience Manager as a Cloud Service (ENTERPRISE_PRODUCT,Cloud Manager,DX - E123)"
+        },
+        {
+          "type": "DEVELOPER_GROUP",
+          "groupName": "_developer_Adobe Document Cloud for business",
+          "memberCount": 5,
+          "productProfileName": "Adobe Document Cloud for business"
+        }
+    ]
+}


### PR DESCRIPTION
Filter out non user groups as those may have duplicate names. Never fail for duplicates, but just use the first one then.

This closes #789