### PR TITLE
Switch to Tomcat 9.0.104 dependencies

### DIFF
--- a/accesscontroltool-bundle/bnd.bnd
+++ b/accesscontroltool-bundle/bnd.bnd
@@ -16,7 +16,7 @@ org.apache.http.*;resolution:=optional,\
 org.bouncycastle.*;resolution:=optional,\
 org.apache.sling.commons.scheduler.*;resolution:=optional,\
 org.apache.jackrabbit.oak.spi.security.principal;version="[1.5.0,3)",\
-!jakarta.servlet*,\
+!javax.servlet.jsp.el,\
 *
 
 # snakeyaml 2.0 uses multi version jars which are not supported: https://github.com/bndtools/bnd/issues/3514

--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -24,7 +24,7 @@
     <description>The OSGi bundle containing all classes of the Access Control Tool.</description>
     
     <properties>
-        <tomcat.el.version>10.0.27</tomcat.el.version>
+        <tomcat.el.version>9.0.104</tomcat.el.version>
         <oak.testing.version>1.48.0</oak.testing.version><!-- ITs require a newer version of Oak otherwise it won't work with Java 11 and certain classes for running the IT are not available -->
     </properties>
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluator.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluator.java
@@ -22,17 +22,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.el.ArrayELResolver;
-import jakarta.el.BeanELResolver;
-import jakarta.el.CompositeELResolver;
-import jakarta.el.ELContext;
-import jakarta.el.ELResolver;
-import jakarta.el.ExpressionFactory;
-import jakarta.el.FunctionMapper;
-import jakarta.el.ListELResolver;
-import jakarta.el.MapELResolver;
-import jakarta.el.ValueExpression;
-import jakarta.el.VariableMapper;
+import javax.el.ArrayELResolver;
+import javax.el.BeanELResolver;
+import javax.el.CompositeELResolver;
+import javax.el.ELContext;
+import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
+import javax.el.FunctionMapper;
+import javax.el.ListELResolver;
+import javax.el.MapELResolver;
+import javax.el.ValueExpression;
+import javax.el.VariableMapper;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringEscapeUtils;

--- a/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluatorTest.java
+++ b/accesscontroltool-bundle/src/test/java/biz/netcentric/cq/tools/actool/configreader/YamlMacroElEvaluatorTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import jakarta.el.ELException;
+import javax.el.ELException;
 
 class YamlMacroElEvaluatorTest {
     private YamlMacroElEvaluator elEvaluator;

--- a/docs/AdvancedFeatures.md
+++ b/docs/AdvancedFeatures.md
@@ -2,7 +2,7 @@
 
 ## Expressions
 
-Expressions are evaluated using the [Jakarta Expression Language 4.0](https://jakarta.ee/specifications/expression-language/4.0/jakarta-expression-language-spec-4.0.html) (since v3.0.3 of the AC tool, before [javax.el EL 2.2](https://docs.oracle.com/javaee/6/tutorial/doc/gjddd.html) was used). They can be used anywhere in the YAML and are processed after YAML parsing and interpolation. Note though that only the [*Immediate Evaluation* syntax `${...}`](https://docs.oracle.com/javaee/6/tutorial/doc/bnahr.html#bnahs) is supported but not the *Deferred Evaluation* syntax (`#{...}`).
+Expressions are evaluated using the [Expression Language 3.0](https://jcp.org/en/jsr/detail?id=341) (since v3.6.0 of the AC tool, before [javax.el EL 2.2](https://docs.oracle.com/javaee/6/tutorial/doc/gjddd.html) was used). They can be used anywhere in the YAML and are processed after YAML parsing and interpolation. Note though that only the [*Immediate Evaluation* syntax `${...}`](https://docs.oracle.com/javaee/6/tutorial/doc/bnahr.html#bnahs) is supported but not the *Deferred Evaluation* syntax (`#{...}`).
 
 The following utility functions are made available to any EL expression used in YAML.
 They can either be used standalone or combined with the [default EL operators](https://docs.oracle.com/javaee/6/tutorial/doc/bnaik.html).


### PR DESCRIPTION
This is the last (maintained) version still compatible with Java 8. Compare with https://tomcat.apache.org/whichversion.html.

This closes #807