### PR TITLE
Fix REPLICATE_PRIVILEGE constant.

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aem/AcToolCqActions.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/aem/AcToolCqActions.java
@@ -61,7 +61,7 @@ public class AcToolCqActions {
     }
 
     private static final String CONTENT_RESTRICTION = "*/jcr:content*";
-    private static final String REPLICATE_PRIVILEGE = "rep:replicate";
+    private static final String REPLICATE_PRIVILEGE = "{http://www.day.com/crx/1.0}replicate";
 
     private final Session session;
     private final Map<String, Set<Privilege>> map = new HashMap<>();


### PR DESCRIPTION
Fixes #811.

The removal of the uber-jar dependency in #802 has introduced an incorrect name for the privilege that is not understood by AEM.