### PR TITLE
Dependency to oak-auth-external should be optional

### DIFF
--- a/accesscontroltool-bundle/bnd.bnd
+++ b/accesscontroltool-bundle/bnd.bnd
@@ -14,8 +14,8 @@ com.adobe.granite.jmx.annotation;resolution:=optional,\
 com.fasterxml.jackson.databind;resolution:=optional,\
 org.apache.http.*;resolution:=optional,\
 org.bouncycastle.*;resolution:=optional,\
-org.apache.sling.commons.scheduler.*;resolution:=optional,\
 org.apache.jackrabbit.oak.spi.security.principal;version="[1.5.0,3)",\
+org.apache.jackrabbit.oak.spi.security.authentication.external.*;resolution:=optional,\
 !jakarta.servlet.jsp.el,\
 *
 


### PR DESCRIPTION
This closes #849