### PR TITLE
Simplify release process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
         <jackrabbit.version>2.20.10</jackrabbit.version><!-- keep those in sync with the ones from io.wcm.maven.aem-dependencies -->
         <oak.version>1.22.16</oak.version>
         <njord.version>0.8.3</njord.version>
+        <!-- https://maveniverse.eu/docs/njord/configuration/#global-properties -->
+        <njord.autoPublish>true</njord.autoPublish>
+        <njord.publishingType>automatic</njord.publishingType>
+        <njord.waitForStates>true</njord.waitForStates>
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
     </properties>
 
     <modules>


### PR DESCRIPTION
Automatically publish to Sonatype Central Portal and afterwards to Maven Central
Wait until deployment is complete
Enable Njord in POM. Settings.xml are only necessary for the credentials.