### PR TITLE
Remove admin ACLs following Oak Best practices

### DIFF
--- a/accesscontroltool-apps-package/src/main/jcr_root/apps/netcentric/actool/content/overview/_rep_policy.xml
+++ b/accesscontroltool-apps-package/src/main/jcr_root/apps/netcentric/actool/content/overview/_rep_policy.xml
@@ -19,12 +19,4 @@
         jcr:primaryType="rep:DenyACE"
         rep:principalName="everyone"
         rep:privileges="{Name}[jcr:read]"/>
-    <allow1
-        jcr:primaryType="rep:GrantACE"
-        rep:principalName="admin"
-        rep:privileges="{Name}[jcr:read]"/>
-    <allow2
-        jcr:primaryType="rep:GrantACE"
-        rep:principalName="administrators"
-        rep:privileges="{Name}[jcr:read]"/>
 </jcr:root>


### PR DESCRIPTION
As mentioned in [Oak authorization best practices](https://jackrabbit.apache.org/oak/docs/security/authorization/bestpractices.html#avoid-redundancy) avoiding duplicity by removing ACLs for administrative principals