### PR TITLE
Introduce HistoryEntry with ZonedDateTime

### DIFF
--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/api/HistoryEntry.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/api/HistoryEntry.java
@@ -15,6 +15,7 @@ package biz.netcentric.cq.tools.actool.api;
  */
 
 import java.sql.Timestamp;
+import java.time.ZonedDateTime;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -24,23 +25,45 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public final class HistoryEntry {
 
-    private Timestamp timestamp;
+    private ZonedDateTime date;
     private String message;
     private long index;
 
+    /**
+     * Creates a new history entry. Calls {@link #HistoryEntry(long, ZonedDateTime, String)} internally with a converted timestamp using the current time zone.
+     * @param index
+     * @param timestamp
+     * @param message
+     * @deprecated Use {@link #HistoryEntry(long, ZonedDateTime, String)} instead.
+     */
+    @Deprecated
     public HistoryEntry(long index, Timestamp timestamp, String message) {
+        this(index, timestamp.toInstant().atZone(ZonedDateTime.now().getZone()), message);
+    }
+
+    public HistoryEntry(long index, ZonedDateTime date, String message) {
         super();
         this.index = index;
-        this.timestamp = timestamp;
+        this.date = date;
         this.message = message;
     }
 
+    @Deprecated
     public Timestamp getTimestamp() {
-        return timestamp;
+        return Timestamp.from(date.toInstant());
     }
 
+    @Deprecated
     public void setTimestamp(Timestamp timestamp) {
-        this.timestamp = timestamp;
+        setDate(timestamp.toInstant().atZone(ZonedDateTime.now().getZone()));
+    }
+
+    public ZonedDateTime getDate() {
+        return date;
+    }
+
+    public void setDate(ZonedDateTime date) {
+        this.date = date;
     }
 
     public String getMessage() {
@@ -61,7 +84,7 @@ public final class HistoryEntry {
 
 	@Override
 	public String toString() {
-		return "HistoryEntry [timestamp=" + timestamp + ", message=" + message
+		return "HistoryEntry [date=" + date + ", message=" + message
 				+ ", index=" + index + "]";
 	}
 

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/api/package-info.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/api/package-info.java
@@ -1,4 +1,4 @@
-@Version("3.3.0")
+@Version("3.4.0")
 package biz.netcentric.cq.tools.actool.api;
 
 /*-

--- a/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/PersistableInstallationLogger.java
+++ b/accesscontroltool-bundle/src/main/java/biz/netcentric/cq/tools/actool/history/impl/PersistableInstallationLogger.java
@@ -22,6 +22,7 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
@@ -141,8 +142,7 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
     }
 
     protected void addWarning(String warning) {
-        warnings.add(new HistoryEntry(msgIndex, new Timestamp(
-                new Date().getTime()), MSG_IDENTIFIER_WARNING + warning));
+        warnings.add(new HistoryEntry(msgIndex, ZonedDateTime.now(), MSG_IDENTIFIER_WARNING + warning));
         listeners.forEach(l -> l.accept(InstallationLogLevel.WARNING, warning));
         msgIndex++;
     }
@@ -154,8 +154,7 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
     }
 
     protected void addMessage(String message) {
-        messages.add(new HistoryEntry(msgIndex, new Timestamp(new Date()
-                .getTime()), " " + message));
+        messages.add(new HistoryEntry(msgIndex, ZonedDateTime.now(), " " + message));
         listeners.forEach(l -> l.accept(InstallationLogLevel.INFO, message));
         msgIndex++;
     }
@@ -175,8 +174,7 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
         if (e != null) {
             fullErrorValue += " / e=" + e;
         }
-        errors.add(new HistoryEntry(msgIndex, new Timestamp(
-                new Date().getTime()), MSG_IDENTIFIER_ERROR + fullErrorValue));
+        errors.add(new HistoryEntry(msgIndex, ZonedDateTime.now(), MSG_IDENTIFIER_ERROR + fullErrorValue));
         listeners.forEach(l -> l.accept(InstallationLogLevel.ERROR, error));
         success = false;
         msgIndex++;
@@ -195,8 +193,7 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
     }
 
     protected void addVerboseMessage(String message) {
-        verboseMessages.add(new HistoryEntry(msgIndex, new Timestamp(
-                new Date().getTime()), " " + message));
+        verboseMessages.add(new HistoryEntry(msgIndex, ZonedDateTime.now(), " " + message));
         listeners.forEach(l -> l.accept(InstallationLogLevel.TRACE, message));
         msgIndex++;
     }
@@ -268,7 +265,7 @@ public class PersistableInstallationLogger implements InstallationLogger, Instal
         StringBuilder sb = new StringBuilder();
         if (!messageHistorySet.isEmpty()) {
             for (HistoryEntry entry : messageHistorySet) {
-                sb.append(EOL + timestampFormat.format(entry.getTimestamp()) + ": "
+                sb.append(EOL + timestampFormat.format(entry.getDate()) + ": "
                         + entry.getMessage());
             }
         }


### PR DESCRIPTION
Deprecate usage of java.sql.Timestamp.
Get rid of all deprecated calls inside ACTool.

This relates to #867