### PR TITLE
Updated tomcat-el version reducing vulnerabilities list

### DIFF
--- a/accesscontroltool-bundle/pom.xml
+++ b/accesscontroltool-bundle/pom.xml
@@ -24,7 +24,7 @@
     <description>The OSGi bundle containing all classes of the Access Control Tool.</description>
     
     <properties>
-        <tomcat.el.version>10.1.52</tomcat.el.version>
+        <tomcat.el.version>10.1.54</tomcat.el.version>
         <oak.testing.version>1.74.0</oak.testing.version><!-- ITs require a newer version of Oak otherwise it won't work with Java 23+ (https://issues.apache.org/jira/browse/OAK-11199) and certain classes for running the IT are not available -->
     </properties>
 


### PR DESCRIPTION
Closes #874

Updating tomcat-el minor version to reduce the number of CVEs associated to that library version. 

org.apache.tomcat:tomcat-el-api @ 10.1.52
- CVE-2026-29145 — Critical (9.1)
- CVE-2016-5425 — High (7.8)
- CVE-2016-6325 — High (7.8)
- CVE-2026-24880 — High (7.5)
- CVE-2026-29129 — High (7.5)
- CVE-2026-29146 — High (7.5)
- CVE-2026-34483 — High (7.5)
- CVE-2026-34487 — High (7.5)
- CVE-2026-34500 — Medium (6.5)
- CVE-2026-25854 — Medium (6.1)
- CVE-2026-32990 — Medium (5.3)

org.apache.tomcat:tomcat-el-api @ 10.1.54
- CVE-2016-5425 — High (7.8)
- CVE-2016-6325 — High (7.8)