### PR TITLE
Remove imports for java.* packages

### DIFF
--- a/accesscontroltool-bundle/bnd.bnd
+++ b/accesscontroltool-bundle/bnd.bnd
@@ -4,7 +4,8 @@ Bundle-SymbolicName: biz.netcentric.cq.tools.accesscontroltool.bundle
 -exportcontents: ${packages;VERSIONED}
 # Embed (https://groups.google.com/g/bndtools-users/c/NAdU0_X8OKY)
 -includeresource: tomcat-el-api-[0-9.]*.jar;lib:=true,tomcat-jasper-el-[0-9.]*.jar;lib:=true,snakeyaml-[0-9.]*.jar;lib:=true
-
+# don't generate java.* package imports to work with Felix 6.0.2 (AEM 6.5.x) not exporting those by mistake (https://issues.apache.org/jira/browse/FELIX-5843)
+-noimportjava: true
 # allow to run in Sling without AEM bundles
 # allow to run without bouncycastle which is only necessary for some edge cases when managing keys
 # broader version range for JMX annotation as 2.0.0 was introduced in https://github.com/apache/jackrabbit-oak/commit/42b0a70d305372e9c228697012f12c59d643fe27#diff-776354a994a5afefbc8da17a75d83569e198589f2abe3be6890bb621f9a1a708 but is still compatible with our use cases

--- a/accesscontroltool-startuphook-bundle/bnd.bnd
+++ b/accesscontroltool-startuphook-bundle/bnd.bnd
@@ -1,3 +1,5 @@
 Bundle-SymbolicName: biz.netcentric.cq.tools.accesscontroltool.startuphook.bundle
 Bundle-Activator: biz.netcentric.cq.tools.actool.startuphook.impl.StartupBundleActivator
 Conditional-Package: biz.netcentric.cq.tools.actool.helper.runtime
+# don't generate java.* package imports to work with Felix 6.0.2 (AEM 6.5.x) not exporting those by mistake (https://issues.apache.org/jira/browse/FELIX-5843)
+-noimportjava: true


### PR DESCRIPTION
This is necessary to support AEM 6.5.x (shipping with Felix 6.0.2) where not all provided java packages are properly exported. This affects e.g. java.sql. Further info in
https://issues.apache.org/jira/browse/FELIX-5843

This closes #865